### PR TITLE
Feature: 공통 Button 컴포넌트 구현 (#3)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/nextjs-vite';
+import '../app/globals.css';
 
 const preview: Preview = {
   parameters: {

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,7 +18,7 @@
   --color-pink-800: #8a393f;
   --color-pink-700: #b14d55;
   --color-pink-600: #d4636d;
-  --color-pink-500: #f47c84;
+  --color-pink-500: #ff7b84;
   --color-pink-400: #f7969d;
   --color-pink-300: #f9afb5;
   --color-pink-200: #fbc9cd;

--- a/components/common/button/Button.stories.tsx
+++ b/components/common/button/Button.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Common/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'outline', 'ghost'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: '생성하기', variant: 'primary', size: 'md' },
+};
+
+export const Outline: Story = {
+  args: { children: '생성하기', variant: 'outline', size: 'md' },
+};
+
+export const Ghost: Story = {
+  args: { children: '생성하기', variant: 'ghost', size: 'sm' },
+};
+
+export const Disabled: Story = {
+  args: { children: '생성하기', variant: 'primary', size: 'md', disabled: true },
+};

--- a/components/common/button/Button.tsx
+++ b/components/common/button/Button.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/utils/cn';
+
+type ButtonSize = 'sm' | 'md' | 'lg';
+type ButtonVariant = 'primary' | 'outline' | 'ghost';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+  children: React.ReactNode;
+}
+
+const BASE_STYLES =
+  'cursor-pointer rounded-lg font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+
+const SIZE_STYLES: Record<ButtonSize, string> = {
+  sm: 'w-20 py-1.5 text-sm',
+  md: 'w-35 py-2 text-base',
+  lg: 'w-90 py-4.5 text-lg font-semibold',
+};
+
+const VARIANT_STYLES: Record<ButtonVariant, string> = {
+  primary: 'bg-pink-500 text-white hover:bg-pink-600 disabled:hover:bg-pink-500',
+  outline:
+    'border border-pink-500 text-pink-500 hover:border-pink-600 hover:text-pink-600 disabled:border-black-700 disabled:text-black-700 disabled:hover:border-black-700 disabled:hover:text-black-700',
+  ghost: 'bg-transparent text-black-700 hover:underline disabled:hover:no-underline',
+};
+
+export function Button({
+  size = 'md',
+  variant = 'primary',
+  className = '',
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(BASE_STYLES, SIZE_STYLES[size], VARIANT_STYLES[variant], className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "@sentry/nextjs": "^10.49.0",
     "@tanstack/react-query": "^5.99.2",
     "axios": "^1.15.1",
+    "clsx": "^2.1.1",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       axios:
         specifier: ^1.15.1
         version: 1.15.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -26,6 +29,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -2287,6 +2293,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -4036,6 +4046,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -6697,6 +6710,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -8618,6 +8633,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?): 
  - 재사용 가능한 공통 Button 컴포넌트를 구현하고, Tailwind 클래스 충돌 방지 및 조건부 클래스 적용을 위한 cn 유틸 추가
- ## 주요 변경(무엇을?): 
  - Button 컴포넌트 구현, Storybook 스토리 작성

## 변경 내용

- [x] cn 유틸 추가 (clsx + tailwind-merge)
- [x] 공통 Button 컴포넌트 구현
- [x] Button Storybook 스토리 작성

### 세부 변경 사항

- utils/cn.ts: Tailwind 클래스 충돌 방지 및 조건부 클래스 적용을 위한 cn 유틸 추가
- components/common/button/Button.tsx: primary, outline, ghost variant / sm, md, lg 사이즈 / disabled 상태 구현
- components/common/button/Button.stories.tsx: variant별 스토리 작성 (Primary, Outline, Ghost, Disabled)
- .storybook/preview.ts: Tailwind 스타일 적용을 위한 globals.css import 추가

## 스크린샷/동영상 (선택)
<img width="1408" height="708" alt="스크린샷 2026-04-23 오전 3 15 24" src="https://github.com/user-attachments/assets/6f76402c-1feb-4548-9cfa-abee0ba20cd2" />


## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #3 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Button component with primary, outline, and ghost variants in small, medium, and large sizes.

* **Style**
  * Updated the pink color value in the design system theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->