### PR TITLE
Feature: 공통 Select 컴포넌트 구현 (#6)

### DIFF
--- a/app/assets/icons/CheckIcon.svg
+++ b/app/assets/icons/CheckIcon.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M3.40198 8.10205L6.66032 11.3604C6.7353 11.4354 6.85688 11.4354 6.93186 11.3604L12.4984 5.79389" stroke="#343434" stroke-linecap="round"/>
 </svg>

--- a/app/assets/icons/CheckIcon.svg
+++ b/app/assets/icons/CheckIcon.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.40198 8.10205L6.66032 11.3604C6.7353 11.4354 6.85688 11.4354 6.93186 11.3604L12.4984 5.79389" stroke="#343434" stroke-linecap="round"/>
+</svg>

--- a/app/assets/icons/ChevronDownIcon.svg
+++ b/app/assets/icons/ChevronDownIcon.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.8 5.6001L8.00005 10.4001L3.20005 5.6001" stroke="#343434" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/icons/ChevronDownIcon.svg
+++ b/app/assets/icons/ChevronDownIcon.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M12.8 5.6001L8.00005 10.4001L3.20005 5.6001" stroke="#343434" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,6 +40,7 @@
   /* Black */
   --color-black-800: #343434;
   --color-black-700: #585858;
+  --color-black-600: #8a8a8a;
   --color-black-560: #8a8a8a;
   --color-black-500: #9d9d9d;
   --color-black-400: #cdcdcd;

--- a/components/common/select/Select.stories.tsx
+++ b/components/common/select/Select.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+import { Select } from './Select';
+
+const OPTIONS_SORT = [
+  { label: '추천순', value: 'recommend' },
+  { label: '최신순', value: 'latest' },
+  { label: '좋아요순', value: 'likes' },
+];
+
+const OPTIONS_AGE = [
+  { label: '만 0세', value: '0' },
+  { label: '만 1세', value: '1' },
+  { label: '만 2세', value: '2' },
+  { label: '만 3세', value: '3' },
+  { label: '만 4세', value: '4' },
+  { label: '만 5세', value: '5' },
+];
+
+const meta: Meta<typeof Select> = {
+  title: 'Common/Select',
+  component: Select,
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Small: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Select
+        size="sm"
+        options={OPTIONS_SORT}
+        triggerLabel="추천순"
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+export const MediumSingle: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Select
+        size="md"
+        options={OPTIONS_AGE}
+        triggerLabel="연령"
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+const OPTIONS_DEVELOPMENT = [
+  { label: '신체 운동 · 건강', value: 'physical' },
+  { label: '의사소통', value: 'communication' },
+  { label: '사회관계', value: 'social' },
+  { label: '예술경험', value: 'art' },
+  { label: '자연탐구', value: 'nature' },
+];
+
+export const MediumMultiple: Story = {
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <Select
+        multiple
+        size="md"
+        options={OPTIONS_DEVELOPMENT}
+        triggerLabel="발달 영역"
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -51,7 +51,7 @@ export function Select(props: SelectProps) {
       props.onChange?.(next);
     } else {
       props.onChange?.(optionValue);
-      setIsOpen(false);
+      if (size === 'sm') setIsOpen(false);
     }
   }
 

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -67,7 +67,7 @@ export function Select(props: SelectProps) {
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          'flex w-full cursor-pointer items-center gap-1 p-2.5 text-sm font-medium text-black-800 outline-none',
+          'flex w-full cursor-pointer items-center gap-1 p-2.5 text-sm font-medium text-black-800 outline-none focus-visible:ring-2 focus-visible:ring-black-400',
           TRIGGER_STYLES[size],
           isOpen && size === 'md' && 'rounded-b-none',
         )}

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import CheckIcon from '@/app/assets/icons/CheckIcon.svg';
+import ChevronDownIcon from '@/app/assets/icons/ChevronDownIcon.svg';
+import { cn } from '@/utils/cn';
+import type { SelectProps, SelectSize } from './select.type';
+
+const SIZE_STYLES: Record<SelectSize, string> = {
+  sm: 'w-25',
+  md: 'w-90',
+};
+
+const TRIGGER_STYLES: Record<SelectSize, string> = {
+  sm: 'justify-end',
+  md: 'justify-between rounded-lg border border-black-300',
+};
+
+const ICON_SIZE: Record<SelectSize, number> = {
+  sm: 16,
+  md: 20,
+};
+
+export function Select(props: SelectProps) {
+  const { size = 'sm', options, triggerLabel = '', className } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iconSize = ICON_SIZE[size];
+
+  useEffect(() => {
+    function handleOutsideClick(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, []);
+
+  function isSelected(optionValue: string): boolean {
+    if (props.multiple) return (props.value ?? []).includes(optionValue);
+    return props.value === optionValue;
+  }
+
+  function handleOptionClick(optionValue: string) {
+    if (props.multiple) {
+      const current = props.value ?? [];
+      const next = current.includes(optionValue)
+        ? current.filter((value) => value !== optionValue)
+        : [...current, optionValue];
+      props.onChange?.(next);
+    } else {
+      props.onChange?.(optionValue);
+      setIsOpen(false);
+    }
+  }
+
+  function getTriggerLabel(): string {
+    if (size === 'md') return triggerLabel;
+    const selectedOption = options.find((option) => option.value === props.value);
+    return selectedOption?.label ?? triggerLabel;
+  }
+
+  return (
+    <div ref={containerRef} className={cn('relative', SIZE_STYLES[size], className)}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={cn(
+          'flex w-full cursor-pointer items-center gap-1 p-2.5 text-sm font-medium text-black-800 outline-none',
+          TRIGGER_STYLES[size],
+          isOpen && size === 'md' && 'rounded-b-none',
+        )}
+      >
+        <span>{getTriggerLabel()}</span>
+        <ChevronDownIcon
+          width={iconSize}
+          height={iconSize}
+          className={cn('shrink-0 transition-transform', isOpen ? 'rotate-180' : 'rotate-0')}
+        />
+      </button>
+
+      {isOpen && (
+        <ul
+          className={cn(
+            'absolute top-full z-100 w-full bg-white',
+            size === 'md'
+              ? 'border-x border-b border-black-300'
+              : 'rounded-b-lg [box-shadow:0_1px_8px_0_rgba(0,0,0,0.04)]',
+          )}
+        >
+          {options.map((option, index) => {
+            const selected = isSelected(option.value);
+            const isLast = index === options.length - 1;
+            return (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  onClick={() => handleOptionClick(option.value)}
+                  className={cn(
+                    'flex w-full cursor-pointer items-center gap-1 p-2.5 text-sm font-medium text-black-700 transition-colors hover:bg-black-100',
+                    selected ? 'bg-black-200' : 'bg-white',
+                    size === 'sm'
+                      ? selected
+                        ? 'justify-end'
+                        : 'justify-center'
+                      : 'justify-between',
+                    size === 'sm' && isLast && 'rounded-b-lg',
+                  )}
+                >
+                  <span>{option.label}</span>
+                  {selected && (
+                    <CheckIcon width={iconSize} height={iconSize} className="shrink-0" />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/common/select/index.ts
+++ b/components/common/select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from './Select';
+export type { SelectOption, SelectProps } from './select.type';

--- a/components/common/select/select.type.ts
+++ b/components/common/select/select.type.ts
@@ -1,0 +1,27 @@
+export type SelectSize = 'sm' | 'md';
+
+export interface SelectOption {
+  label: string;
+  value: string;
+}
+
+interface SelectSharedProps {
+  size?: SelectSize;
+  options: SelectOption[];
+  triggerLabel?: string;
+  className?: string;
+}
+
+interface SingleSelectProps extends SelectSharedProps {
+  multiple?: false;
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+interface MultiSelectProps extends SelectSharedProps {
+  multiple: true;
+  value?: string[];
+  onChange?: (value: string[]) => void;
+}
+
+export type SelectProps = SingleSelectProps | MultiSelectProps;


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 재사용 가능한 공통 Select 컴포넌트를 구현
- ## 주요 변경(무엇을?): 
  - Select 컴포넌트 구현, Storybook 스토리 작성, 아이콘 svg 추가

## 변경 내용

- [x] 공통 Select 컴포넌트 구현
- [x] Select 타입 파일 분리 및 배럴 export 추가
- [x] Select Storybook 스토리 작성

### 세부 변경 사항

  - `select.type.ts`: single/multiple 여부에 따라 value와 onChange 타입이 달라지도록 타입 분리                                    
  - `index.ts`: 배럴 export 추가로 import 경로 일관성 확보                 
       - 여러 파일에서 직접 import 하던 구조를 하나의 진입점으로 통합했습니다.     
       ```ts
      // before
      import { Select } from '@/components/select/select';
      import { SelectOption } from '@/components/select/select.type';
       ``` 
       ```ts
      // after
      import { Select, SelectOption } from '@/components/select';
       ```                
       -  추후 아이콘을 import 하는 경우에도 배럴 export로 관리하면 import 경로를 일관되게 유지할 수 있습니다.               
       ```ts
      // before
      // 여러 파일을 개별적으로 import 해야 하는 경우
      import CheckIcon from '@/components/icon/CheckIcon';
      import ChevronDownIcon from '@/components/icon/ChevronDownIcon';
      import CloseIcon from '@/components/icon/CloseIcon';
       ```    
       ```ts
      // after
      import { CheckIcon, ChevronDownIcon, CloseIcon } from '@/components/icon';
       ```    
  - sm은 항상 single select, 선택 시 드롭다운 닫힘 / md는 single과 multiple 모두 지원, 선택 후 드롭다운 유지
  - CheckIcon, ChevronDownIcon SVG 파일의 하드코딩된 width/height 제거                                                        
  - `globals.css`: black-600 색상 변수 추가

## 스크린샷/동영상 (선택)
- sm (single)
  <img width="1334" height="622" alt="스크린샷 2026-04-25 오후 11 45 37" src="https://github.com/user-attachments/assets/5fca4c10-3c2b-486a-bb2a-7d8126aad49a" />

- md (single)
  <img width="1334" height="622" alt="스크린샷 2026-04-25 오후 11 46 11" src="https://github.com/user-attachments/assets/c5722e78-aef1-43ed-b0a1-51f08a476938" />

- md (multiple)
  <img width="1334" height="622" alt="스크린샷 2026-04-25 오후 11 46 34" src="https://github.com/user-attachments/assets/cc53f75a-71cb-466e-ab3c-96727fc23827" />


## 테스트

- [ ] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Select component with single and multiple selection modes, size variants, selectable option indicators, and configurable trigger labeling.

* **Style**
  * Extended theme with an additional mid-tone black color token.

* **Documentation**
  * Storybook stories demonstrating the Select component in small, medium single, and medium multi configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->