### PR TITLE
Feature: 공통 Button 컴포넌트 full-width 옵션 추가 (#19)

### DIFF
--- a/components/common/button/Button.stories.tsx
+++ b/components/common/button/Button.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Button> = {
     },
     size: {
       control: 'select',
-      options: ['sm', 'md', 'lg'],
+      options: ['full', 'sm', 'md', 'lg'],
     },
     disabled: { control: 'boolean' },
   },
@@ -34,4 +34,12 @@ export const Ghost: Story = {
 
 export const Disabled: Story = {
   args: { children: '생성하기', variant: 'primary', size: 'md', disabled: true },
+};
+
+export const FullPrimary: Story = {
+  args: { children: '시작하기', variant: 'primary', size: 'full' },
+};
+
+export const FullOutline: Story = {
+  args: { children: '시작하기', variant: 'outline', size: 'full' },
 };

--- a/components/common/button/Button.tsx
+++ b/components/common/button/Button.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn';
 
-type ButtonSize = 'sm' | 'md' | 'lg';
+type ButtonSize = 'full' | 'sm' | 'md' | 'lg';
 type ButtonVariant = 'primary' | 'outline' | 'ghost';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -13,6 +13,7 @@ const BASE_STYLES =
   'cursor-pointer rounded-lg font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
 
 const SIZE_STYLES: Record<ButtonSize, string> = {
+  full: 'w-full py-2 text-base',
   sm: 'w-20 py-1.5 text-sm',
   md: 'w-35 py-2 text-base',
   lg: 'w-90 py-4.5 text-lg font-semibold',


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 디자인 변경에 따라 Button 컴포넌트에 full-width 옵션을 지원하기 위함
- ## 주요 변경(무엇을?):
  - Button 컴포넌트에 full-width 옵션 추가
  
## 변경 내용

- [x] Button 컴포넌트에 full-width 옵션 추가

### 세부 변경 사항

- `Button`: full-width prop 추가

## 스크린샷/동영상 (선택)

- full (primary)
  <img width="599" height="457" alt="스크린샷 2026-04-26 오전 2 56 05" src="https://github.com/user-attachments/assets/8c5d8c05-c71e-442b-be44-cf6d75fa37b5" />

- full (outline)
  <img width="599" height="457" alt="스크린샷 2026-04-26 오전 2 56 19" src="https://github.com/user-attachments/assets/9faf242c-b833-4aa1-89e3-98ef45e8e7c2" />


## 테스트

- [ ] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #19 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a new full-width size option for buttons, allowing buttons to expand to fill their container width. Available with both primary and outline variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->