### PR TITLE
Feature: 사이드바 기능 수정 (#40)

### DIFF
--- a/components/common/sidebar/Sidebar.tsx
+++ b/components/common/sidebar/Sidebar.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { getSidebarConfig } from '@/constants/community/sidebar-config';
+import { getSidebarConfig } from '@/constants/common/sidebar-config';
 import SidebarTab from './SidebarTab';
+
+function isSidebarTabActive(pathname: string, href: string) {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
 
 export default function Sidebar() {
   const pathname = usePathname() ?? '';
@@ -17,15 +21,13 @@ export default function Sidebar() {
       <div className="flex h-full flex-col justify-between">
         {sidebarConfig.sections.map((section) => (
           <nav key={section.ariaLabel} aria-label={section.ariaLabel}>
-            <ul className={`${section.className} flex flex-col`}>
+            <ul className="mt-15 ml-20 flex flex-col">
               {section.tabs.map((tab) => (
                 <li key={tab.href}>
                   <SidebarTab
                     label={tab.label}
                     href={tab.href}
-                    isActive={
-                      pathname === tab.href || (tab.href !== '/' && pathname.startsWith(tab.href))
-                    }
+                    isActive={isSidebarTabActive(pathname, tab.href)}
                   />
                 </li>
               ))}

--- a/components/common/sidebar/Sidebar.tsx
+++ b/components/common/sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { getSidebarConfig } from '@/constants/common/sidebar-config';
+import { getSidebarConfig } from '@/utils/sidebar';
 import SidebarTab from './SidebarTab';
 
 function isSidebarTabActive(pathname: string, href: string) {

--- a/components/common/sidebar/Sidebar.tsx
+++ b/components/common/sidebar/Sidebar.tsx
@@ -1,55 +1,37 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { getSidebarConfig } from '@/constants/community/sidebar-config';
 import SidebarTab from './SidebarTab';
-
-const TOP_TABS = [
-  { label: '모아방', href: '/community/moabang' },
-  { label: '자유게시판', href: '/community/board' },
-];
-
-const BOTTOM_TABS = [
-  { label: '내 활동 글', href: '/my/posts' },
-  { label: '작성한 댓글', href: '/my/comments' },
-  { label: '보관함', href: '/my/saved' },
-]; //임시
 
 export default function Sidebar() {
   const pathname = usePathname() ?? '';
+  const sidebarConfig = getSidebarConfig(pathname);
+
+  if (!sidebarConfig.visible) {
+    return null;
+  }
 
   return (
     <aside className="h-full w-89.25 border-r border-black-200" aria-label="사이드 내비게이션">
       <div className="flex h-full flex-col justify-between">
-        <nav aria-label="메인 메뉴">
-          <ul className="mt-15 ml-20 flex flex-col">
-            {TOP_TABS.map((tab) => (
-              <li key={tab.href}>
-                <SidebarTab
-                  label={tab.label}
-                  href={tab.href}
-                  isActive={
-                    pathname === tab.href || (tab.href !== '/' && pathname.startsWith(tab.href))
-                  }
-                />
-              </li>
-            ))}
-          </ul>
-        </nav>
-        <nav aria-label="내 활동 메뉴">
-          <ul className="mb-39.25 ml-20 flex flex-col">
-            {BOTTOM_TABS.map((tab) => (
-              <li key={tab.href}>
-                <SidebarTab
-                  label={tab.label}
-                  href={tab.href}
-                  isActive={
-                    pathname === tab.href || (tab.href !== '/' && pathname.startsWith(tab.href))
-                  }
-                />
-              </li>
-            ))}
-          </ul>
-        </nav>
+        {sidebarConfig.sections.map((section) => (
+          <nav key={section.ariaLabel} aria-label={section.ariaLabel}>
+            <ul className={`${section.className} flex flex-col`}>
+              {section.tabs.map((tab) => (
+                <li key={tab.href}>
+                  <SidebarTab
+                    label={tab.label}
+                    href={tab.href}
+                    isActive={
+                      pathname === tab.href || (tab.href !== '/' && pathname.startsWith(tab.href))
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
       </div>
     </aside>
   );

--- a/constants/common/sidebar-config.ts
+++ b/constants/common/sidebar-config.ts
@@ -6,7 +6,6 @@ export interface SidebarTabItem {
 export interface SidebarSection {
   ariaLabel: string;
   tabs: SidebarTabItem[];
-  className: string;
 }
 
 export interface SidebarConfig {
@@ -23,22 +22,33 @@ const COMMUNITY_TABS: SidebarTabItem[] = [
   { label: '자유게시판', href: '/community/board' },
 ];
 
+const MY_PAGE_TABS: SidebarTabItem[] = [
+  { label: '대시보드', href: '/my/dashboard' },
+  { label: '관찰일지 내역', href: '/my/observations' },
+  { label: '내 활동', href: '/my/activity' },
+  { label: '북마크', href: '/my/bookmarks' },
+];
+
 const SIDEBAR_ROUTE_CONFIGS: SidebarRouteConfig[] = [
   {
     prefix: '/community',
     visible: true,
     sections: [
       {
-        ariaLabel: '메인 메뉴',
+        ariaLabel: '커뮤니티 목록',
         tabs: COMMUNITY_TABS,
-        className: 'mt-15 ml-20',
       },
     ],
   },
   {
     prefix: '/my',
-    visible: false,
-    sections: [],
+    visible: true,
+    sections: [
+      {
+        ariaLabel: '마이페이지 목록',
+        tabs: MY_PAGE_TABS,
+      },
+    ],
   },
 ];
 

--- a/constants/common/sidebar-config.ts
+++ b/constants/common/sidebar-config.ts
@@ -13,7 +13,7 @@ export interface SidebarConfig {
   sections: SidebarSection[];
 }
 
-interface SidebarRouteConfig extends SidebarConfig {
+export interface SidebarRouteConfig extends SidebarConfig {
   prefix: string;
 }
 
@@ -29,7 +29,7 @@ const MY_PAGE_TABS: SidebarTabItem[] = [
   { label: '북마크', href: '/my/bookmarks' },
 ];
 
-const SIDEBAR_ROUTE_CONFIGS: SidebarRouteConfig[] = [
+export const SIDEBAR_ROUTE_CONFIGS: SidebarRouteConfig[] = [
   {
     prefix: '/community',
     visible: true,
@@ -52,15 +52,7 @@ const SIDEBAR_ROUTE_CONFIGS: SidebarRouteConfig[] = [
   },
 ];
 
-const HIDDEN_SIDEBAR_CONFIG: SidebarConfig = {
+export const HIDDEN_SIDEBAR_CONFIG: SidebarConfig = {
   visible: false,
   sections: [],
 };
-
-export function getSidebarConfig(pathname: string): SidebarConfig {
-  const matchedConfig = SIDEBAR_ROUTE_CONFIGS.find(
-    (config) => pathname === config.prefix || pathname.startsWith(`${config.prefix}/`),
-  );
-
-  return matchedConfig ?? HIDDEN_SIDEBAR_CONFIG;
-}

--- a/constants/community/sidebar-config.ts
+++ b/constants/community/sidebar-config.ts
@@ -1,0 +1,56 @@
+export interface SidebarTabItem {
+  label: string;
+  href: string;
+}
+
+export interface SidebarSection {
+  ariaLabel: string;
+  tabs: SidebarTabItem[];
+  className: string;
+}
+
+export interface SidebarConfig {
+  visible: boolean;
+  sections: SidebarSection[];
+}
+
+interface SidebarRouteConfig extends SidebarConfig {
+  prefix: string;
+}
+
+const COMMUNITY_TABS: SidebarTabItem[] = [
+  { label: '모아방', href: '/community/moabang' },
+  { label: '자유게시판', href: '/community/board' },
+];
+
+const SIDEBAR_ROUTE_CONFIGS: SidebarRouteConfig[] = [
+  {
+    prefix: '/community',
+    visible: true,
+    sections: [
+      {
+        ariaLabel: '메인 메뉴',
+        tabs: COMMUNITY_TABS,
+        className: 'mt-15 ml-20',
+      },
+    ],
+  },
+  {
+    prefix: '/my',
+    visible: false,
+    sections: [],
+  },
+];
+
+const HIDDEN_SIDEBAR_CONFIG: SidebarConfig = {
+  visible: false,
+  sections: [],
+};
+
+export function getSidebarConfig(pathname: string): SidebarConfig {
+  const matchedConfig = SIDEBAR_ROUTE_CONFIGS.find(
+    (config) => pathname === config.prefix || pathname.startsWith(`${config.prefix}/`),
+  );
+
+  return matchedConfig ?? HIDDEN_SIDEBAR_CONFIG;
+}

--- a/utils/sidebar.ts
+++ b/utils/sidebar.ts
@@ -1,0 +1,13 @@
+import {
+  HIDDEN_SIDEBAR_CONFIG,
+  SIDEBAR_ROUTE_CONFIGS,
+  type SidebarConfig,
+} from '@/constants/common/sidebar-config';
+
+export function getSidebarConfig(pathname: string): SidebarConfig {
+  const matchedConfig = SIDEBAR_ROUTE_CONFIGS.find(
+    (config) => pathname === config.prefix || pathname.startsWith(`${config.prefix}/`),
+  );
+
+  return matchedConfig ?? HIDDEN_SIDEBAR_CONFIG;
+}


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 기획이 수정되어 사이드바의 기능이 달라졌습니다.
- ## 주요 변경(무엇을?):
  - 사이드바 visible 설정
## 변경 내용

- [ ] 글 쓰기 페이지에서는 active 비활성화
- [x] 마이페이지에서는 항목이 다르게 렌더링
- [x] 하단 탭 제거
- [x] 몇몇의 페이지에서는 숨기기

### 세부 변경 사항

- 사이드바 탭과 경로별 노출 정책을 sidebar-config로 분리해, URL 기준으로 표시 여부와 메뉴 구성을 관리하도록 변경
- 사이드바 active 판별 로직을 정리해 현재 경로와 일치하는 탭만 정확히 활성화되도록 수정
- getSidebarConfig 조회 로직을 utils/sidebar.ts로 분리해 설정 데이터와 계산 로직의 역할을 분리


## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [x] pnpm test 통과
- [x] pnpm build 통과

## 관련 이슈

- close #40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Sidebar now dynamically shows and hides based on the current page location
  * Navigation tabs reorganized into distinct sections for Community and My Page areas
  * Sidebar visibility and tab structure are now route-aware

<!-- end of auto-generated comment: release notes by coderabbit.ai -->