### PR TITLE
Fix: Header를 Providers 내부로 이동하여 QueryClient 에러 수정 (#72)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,8 +31,8 @@ export default async function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable} h-full antialiased`}>
       <body className={`${pretendard.className} flex h-screen flex-col overflow-hidden`}>
-        <Header user={user} />
         <Providers>
+          <Header user={user} />
           <UserInitializer user={user} />
           <div className="flex flex-1 overflow-hidden">
             <Sidebar />


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - Header가 QueryClientProvider 외부에 위치하여 useLogoutMutation 호출 시 "No QueryClient set" 에러 발생 
  
- ## 주요 변경(무엇을?):
  - layout.tsx에서 Header를 Providers 내부로 이동

## 변경 내용

- [x] Header를 QueryClientProvider 범위 안으로 이동

### 세부 변경 사항

- layout.tsx에서 `<Header>`를 `<Providers>` 내부로 이동

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [ ] 유닛 테스트 추가/수정됨
- [ ] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #72 
