### PR TITLE
Feature: 반응형 네비게이션 메뉴 구현 (#88)

### DIFF
--- a/app/assets/icons/HamburgerIcon.svg
+++ b/app/assets/icons/HamburgerIcon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M26.6666 9.33301H5.33325M26.6666 15.9997H5.33325M26.6666 22.6663H5.33325" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/app/assets/icons/MainLogoIcon.svg
+++ b/app/assets/icons/MainLogoIcon.svg
@@ -1,4 +1,4 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <rect width="40" height="40" fill="url(#pattern0_1548_5559)"/>
 <defs>
 <pattern id="pattern0_1548_5559" patternContentUnits="objectBoundingBox" width="1" height="1">

--- a/app/assets/icons/XIcon.svg
+++ b/app/assets/icons/XIcon.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 6L6 18M18 18L6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18M18 18L6 6" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/app/assets/icons/index.ts
+++ b/app/assets/icons/index.ts
@@ -27,3 +27,4 @@ export { default as DetailBookmarkIcon } from './DetailBookmarkIcon.svg';
 export { default as DetailHeartIcon } from './DetailHeartIcon.svg';
 export { default as DownloadIcon } from './DownloadIcon.svg';
 export { default as TopIcon } from './TopIcon.svg';
+export { default as HamburgerIcon } from './HamburgerIcon.svg';

--- a/components/common/header/Header.tsx
+++ b/components/common/header/Header.tsx
@@ -5,13 +5,14 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import { Button } from '@/components/common/button/Button';
-import { MainLogoIcon } from '@/app/assets/icons';
+import { MainLogoIcon, XIcon, HamburgerIcon } from '@/app/assets/icons';
 import { DefaultAvatar } from '@/app/assets/images';
 import { useLoginModalStore } from '@/stores/loginModalStore';
 import { ProfilePopover } from '@/components/common/profile-popover/ProfilePopover';
 import NAV_ITEMS from '@/constants/common/nav-items';
 import { useLogoutMutation } from '@/hooks/queries/auth/useAuth';
 import { useUser } from '@/lib/user-context';
+import NavMenu from '@/components/common/nav-menu/NavMenu';
 
 export default function Header() {
   const openLoginModal = useLoginModalStore((state) => state.open);
@@ -19,6 +20,7 @@ export default function Header() {
   const pathname = usePathname() ?? '';
   const router = useRouter();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);
 
   const { mutate: handleLogout } = useLogoutMutation({
     onSuccess: () => {
@@ -29,14 +31,14 @@ export default function Header() {
   });
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-black-200 px-20">
+    <header className="relative z-300 flex h-12 items-center justify-between border-b border-black-200 bg-white px-4 md:px-9 xl:h-16 xl:px-20">
       <div className="flex items-center gap-8.5">
         <Link href="/" aria-label="모아쌤 홈으로 이동">
-          <MainLogoIcon aria-hidden="true" />
+          <MainLogoIcon className="h-7 w-7 xl:h-10 xl:w-10" aria-hidden="true" />
         </Link>
         <nav
           aria-label="주요 메뉴"
-          className="flex items-center gap-8.5 text-base leading-[140%] font-medium tracking-[-0.02em]"
+          className="hidden items-center gap-8.5 text-base leading-[140%] font-medium tracking-[-0.02em] xl:flex"
         >
           {NAV_ITEMS.map(({ href, label }) => (
             <Link
@@ -54,35 +56,50 @@ export default function Header() {
         </nav>
       </div>
       <div className="relative flex items-center gap-5">
-        {user ? (
-          <>
-            <button
-              className="h-9 w-9 cursor-pointer overflow-hidden rounded-full"
-              onClick={() => setIsPopoverOpen((prev) => !prev)}
-              aria-label="프로필 팝오버 열기"
-            >
-              <Image
-                src={user.profileImageUrl || DefaultAvatar}
-                alt="프로필 아바타"
-                width={36}
-                height={36}
-              />
-            </button>
-            {isPopoverOpen && (
-              <ProfilePopover
-                name={user.nickname}
-                avatarSrc={user.profileImageUrl || DefaultAvatar}
-                onClose={() => setIsPopoverOpen(false)}
-                onLogout={handleLogout}
-              />
-            )}
-          </>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => openLoginModal()}>
-            로그인
-          </Button>
-        )}
+        <button
+          className="xl:hidden"
+          onClick={() => setIsNavMenuOpen((prev) => !prev)}
+          aria-label={isNavMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+          aria-expanded={isNavMenuOpen}
+        >
+          {isNavMenuOpen ? (
+            <XIcon className="h-7 w-7 md:h-8 md:w-8" />
+          ) : (
+            <HamburgerIcon className="h-7 w-7 md:h-8 md:w-8" />
+          )}
+        </button>
+        <div className="hidden md:items-center md:gap-5 xl:flex">
+          {user ? (
+            <>
+              <button
+                className="h-9 w-9 cursor-pointer overflow-hidden rounded-full"
+                onClick={() => setIsPopoverOpen((prev) => !prev)}
+                aria-label="프로필 팝오버 열기"
+              >
+                <Image
+                  src={user.profileImageUrl || DefaultAvatar}
+                  alt="프로필 아바타"
+                  width={36}
+                  height={36}
+                />
+              </button>
+              {isPopoverOpen && (
+                <ProfilePopover
+                  name={user.nickname}
+                  avatarSrc={user.profileImageUrl || DefaultAvatar}
+                  onClose={() => setIsPopoverOpen(false)}
+                  onLogout={handleLogout}
+                />
+              )}
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => openLoginModal()}>
+              로그인
+            </Button>
+          )}
+        </div>
       </div>
+      <NavMenu key={pathname} isOpen={isNavMenuOpen} onLogout={handleLogout} />
     </header>
   );
 }

--- a/components/common/header/Header.tsx
+++ b/components/common/header/Header.tsx
@@ -99,7 +99,12 @@ export default function Header() {
           )}
         </div>
       </div>
-      <NavMenu key={pathname} isOpen={isNavMenuOpen} onLogout={handleLogout} />
+      <NavMenu
+        key={pathname}
+        isOpen={isNavMenuOpen}
+        onClose={() => setIsNavMenuOpen(false)}
+        onLogout={handleLogout}
+      />
     </header>
   );
 }

--- a/components/common/login-modal/LoginModal.tsx
+++ b/components/common/login-modal/LoginModal.tsx
@@ -42,7 +42,7 @@ export function LoginModal() {
           aria-modal="true"
           aria-labelledby="login-modal-title"
         >
-          <MainLogoIcon />
+          <MainLogoIcon className="h-10 w-10" />
           <p id="login-modal-title" className="mt-1.5 text-xl font-semibold text-pink-500">
             {title}
           </p>

--- a/components/common/more-button/MoreButton.tsx
+++ b/components/common/more-button/MoreButton.tsx
@@ -33,7 +33,7 @@ export function MoreButton({ onEdit, onDelete, className }: MoreButtonProps) {
         <DropdownMenu.Content
           align="end"
           sideOffset={6}
-          className="z-100 w-25 overflow-hidden rounded-2xl border border-black-200 bg-white py-2 shadow-[0px_1px_8px_0px_rgba(0,0,0,0.04)]"
+          className="z-500 w-25 overflow-hidden rounded-2xl border border-black-200 bg-white py-2 shadow-[0px_1px_8px_0px_rgba(0,0,0,0.04)]"
         >
           {onEdit && (
             <DropdownMenu.Item asChild onSelect={onEdit}>

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -101,7 +101,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                         <Link
                           href="/mypage/observations"
                           onClick={onClose}
-                          className="mt-2 flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                          className="mt-2 flex items-center gap-2 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           최근 관찰일지
                           <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/utils/cn';
+import { ChevronDownIcon } from '@/app/assets/icons';
+import { DefaultAvatar } from '@/app/assets/images';
+import { useUser } from '@/lib/user-context';
+import { useLoginModalStore } from '@/stores/loginModalStore';
+import { Button } from '@/components/common/button/Button';
+
+interface NavMenuProps {
+  isOpen: boolean;
+  onLogout: () => void;
+}
+
+const NAV_SECTIONS = [
+  {
+    href: '/observations',
+    label: 'AI 관찰일지',
+    children: [
+      { label: '새 관찰일지', href: '/observations' },
+      { label: '관찰일지 목록 보기', href: '/mypage/observations' },
+    ],
+  },
+  {
+    href: '/community',
+    label: '커뮤니티',
+    children: [
+      { label: '모아방', href: '/community/moabang' },
+      { label: '자유게시판', href: '/community/board' },
+    ],
+  },
+];
+
+export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
+  const pathname = usePathname() ?? '';
+  const user = useUser();
+  const openLoginModal = useLoginModalStore((state) => state.open);
+
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      NAV_SECTIONS.map((s) => [s.href, pathname === s.href || pathname.startsWith(s.href + '/')]),
+    ),
+  );
+
+  const toggleSection = (href: string) => {
+    setOpenSections((prev) => ({ ...prev, [href]: !prev[href] }));
+  };
+
+  return (
+    <div
+      className={cn(
+        'absolute top-12 left-0 z-400 w-full overflow-hidden bg-white shadow-md transition-all duration-300 xl:hidden',
+        isOpen ? 'max-h-[calc(100vh-3rem)]' : 'max-h-0',
+      )}
+      aria-hidden={!isOpen}
+    >
+      <nav className="flex min-h-[calc(100vh-3rem)] flex-col justify-between">
+        <div>
+          {NAV_SECTIONS.map((section) => {
+            const isSectionActive =
+              pathname === section.href || pathname.startsWith(section.href + '/');
+            const isSectionOpen = openSections[section.href];
+
+            return (
+              <div key={section.href}>
+                <button
+                  onClick={() => toggleSection(section.href)}
+                  className="flex w-full items-center justify-between px-4 py-3.75 text-base font-medium md:px-9"
+                >
+                  <span
+                    className={cn(isSectionActive ? 'font-semibold text-pink-500' : 'text-black')}
+                  >
+                    {section.label}
+                  </span>
+                  <ChevronDownIcon
+                    className={cn(
+                      'h-4 w-4 text-black transition-transform',
+                      isSectionOpen ? '-rotate-180' : 'rotate-0',
+                    )}
+                  />
+                </button>
+
+                {isSectionOpen && (
+                  <ul className="flex flex-col pb-2">
+                    {section.children.map((child) => {
+                      const isActive = pathname === child.href;
+                      return (
+                        <li key={child.href}>
+                          <Link
+                            href={child.href}
+                            className={cn(
+                              'block px-8 py-3 text-sm leading-[140%] tracking-[-0.02em]',
+                              isActive ? 'font-semibold text-pink-500' : 'font-medium text-black',
+                            )}
+                          >
+                            {child.label}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div>
+          {user ? (
+            <>
+              <Link
+                href="/mypage/dashboard"
+                className="flex items-center gap-5 px-4 py-[18.5px] md:px-9"
+              >
+                <div className="h-12.5 w-12.5 shrink-0 overflow-hidden rounded-full">
+                  <Image
+                    src={user.profileImageUrl || DefaultAvatar}
+                    alt="프로필 아바타"
+                    width={50}
+                    height={50}
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="text-sm font-semibold text-black">{user.nickname} 선생님</span>
+                  <span className="truncate text-xs font-medium text-black-600">{user.email}</span>
+                </div>
+                <ChevronDownIcon className="h-4 w-4 shrink-0 -rotate-90 text-black" />
+              </Link>
+              <div className="flex justify-end bg-black-100 py-4 pr-4 md:pr-9">
+                <button onClick={onLogout} className="text-xs text-black-500">
+                  로그아웃
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="px-4 py-11.75">
+              <Button
+                variant="primary"
+                size="full"
+                className="py-4"
+                onClick={() => openLoginModal()}
+              >
+                로그인
+              </Button>
+            </div>
+          )}
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -101,7 +101,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                         <Link
                           href="/mypage/observations"
                           onClick={onClose}
-                          className="flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                          className="mt-2 flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           최근 관찰일지
                           <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -80,7 +80,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                       <div className="bg-black-100 py-2.5">
                         <Link
                           href="/observations"
-                          className="flex items-center gap-0.5 px-6 py-3.5 text-xs font-semibold text-black md:px-9"
+                          className="flex items-center gap-0.5 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           <PlusIcon className="h-4 w-4 shrink-0" />새 관찰일지
                         </Link>
@@ -88,7 +88,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                           <>
                             <Link
                               href="/mypage/observations"
-                              className="flex items-center gap-2 px-6 py-3 text-xs font-semibold text-black md:px-9"
+                              className="flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                             >
                               최근 관찰일지
                               <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />
@@ -98,7 +98,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                                 <li key={log.observationId}>
                                   <Link
                                     href={`/observations/${log.observationId}`}
-                                    className="flex items-center justify-between px-6 py-3.5 text-xs font-medium text-black-700 md:px-9"
+                                    className="flex items-center justify-between rounded-lg px-6 py-3.5 text-xs font-medium text-black-700 hover:bg-black-200 md:px-9"
                                   >
                                     <span className="truncate">{log.title}</span>
                                     <MoreDotIcon className="h-4 w-4 shrink-0 text-black-600" />
@@ -115,7 +115,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                           <li key={child.href}>
                             <Link
                               href={child.href}
-                              className="block px-6 py-3.5 text-xs font-semibold text-black md:px-9"
+                              className="block rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                             >
                               {child.label}
                             </Link>

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -98,37 +98,35 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                         >
                           <PlusIcon className="h-4 w-4 shrink-0" />새 관찰일지
                         </Link>
+                        <Link
+                          href="/mypage/observations"
+                          onClick={onClose}
+                          className="flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                        >
+                          최근 관찰일지
+                          <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />
+                        </Link>
                         {recentObservations && recentObservations.length > 0 && (
-                          <>
-                            <Link
-                              href="/mypage/observations"
-                              onClick={onClose}
-                              className="flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
-                            >
-                              최근 관찰일지
-                              <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />
-                            </Link>
-                            <ul className="flex flex-col">
-                              {recentObservations.map((log) => (
-                                <li
-                                  key={log.observationId}
-                                  className="group relative flex items-center"
+                          <ul className="flex flex-col">
+                            {recentObservations.map((log) => (
+                              <li
+                                key={log.observationId}
+                                className="group relative flex items-center"
+                              >
+                                <Link
+                                  href={`/observations/${log.observationId}`}
+                                  onClick={onClose}
+                                  className="flex-1 truncate px-6 py-3.5 text-xs font-medium text-black-700 hover:rounded-lg hover:bg-black-200 md:px-9"
                                 >
-                                  <Link
-                                    href={`/observations/${log.observationId}`}
-                                    onClick={onClose}
-                                    className="flex-1 truncate px-6 py-3.5 text-xs font-medium text-black-700 hover:rounded-lg hover:bg-black-200 md:px-9"
-                                  >
-                                    {log.title}
-                                  </Link>
-                                  <MoreButton
-                                    onDelete={() => deleteObservation(log.observationId)}
-                                    className="absolute top-1/2 right-6 -translate-y-1/2 md:right-9"
-                                  />
-                                </li>
-                              ))}
-                            </ul>
-                          </>
+                                  {log.title}
+                                </Link>
+                                <MoreButton
+                                  onDelete={() => deleteObservation(log.observationId)}
+                                  className="absolute top-1/2 right-6 -translate-y-1/2 md:right-9"
+                                />
+                              </li>
+                            ))}
+                          </ul>
                         )}
                       </div>
                     ) : (

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -63,7 +63,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
               <div key={section.href}>
                 <button
                   onClick={() => toggleSection(section.href)}
-                  className="flex w-full items-center justify-between px-4 py-3.75 text-base font-semibold md:px-9"
+                  className="flex w-full items-center justify-between py-3.75 pr-6 pl-4 text-base font-semibold md:px-9"
                 >
                   <span className="text-black">{section.label}</span>
                   <ChevronDownIcon

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -14,6 +14,7 @@ import { useObservationRecentQuery } from '@/hooks/queries/observations/useObser
 
 interface NavMenuProps {
   isOpen: boolean;
+  onClose: () => void;
   onLogout: () => void;
 }
 
@@ -28,7 +29,7 @@ const COMMUNITY_SECTION = {
 
 const NAV_SECTIONS = [{ href: '/observations', label: 'AI 관찰일지' }, COMMUNITY_SECTION];
 
-export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
+export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
   const pathname = usePathname() ?? '';
   const user = useUser();
   const openLoginModal = useLoginModalStore((state) => state.open);
@@ -80,6 +81,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                       <div className="bg-black-100 py-2.5">
                         <Link
                           href="/observations"
+                          onClick={onClose}
                           className="flex items-center gap-0.5 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           <PlusIcon className="h-4 w-4 shrink-0" />새 관찰일지
@@ -88,6 +90,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                           <>
                             <Link
                               href="/mypage/observations"
+                              onClick={onClose}
                               className="flex items-center gap-2 rounded-lg px-6 py-3 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                             >
                               최근 관찰일지
@@ -98,6 +101,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                                 <li key={log.observationId}>
                                   <Link
                                     href={`/observations/${log.observationId}`}
+                                    onClick={onClose}
                                     className="flex items-center justify-between rounded-lg px-6 py-3.5 text-xs font-medium text-black-700 hover:bg-black-200 md:px-9"
                                   >
                                     <span className="truncate">{log.title}</span>
@@ -115,6 +119,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                           <li key={child.href}>
                             <Link
                               href={child.href}
+                              onClick={onClose}
                               className="block rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                             >
                               {child.label}
@@ -135,6 +140,7 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
             <>
               <Link
                 href="/mypage/dashboard"
+                onClick={onClose}
                 className="flex items-center gap-5 px-4 py-[18.5px] md:px-9"
               >
                 <div className="h-12.5 w-12.5 shrink-0 overflow-hidden rounded-full">

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -5,12 +5,17 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/utils/cn';
-import { ChevronDownIcon, MoreDotIcon, PlusIcon } from '@/app/assets/icons';
+import { ChevronDownIcon, PlusIcon } from '@/app/assets/icons';
 import { DefaultAvatar } from '@/app/assets/images';
 import { useUser } from '@/lib/user-context';
 import { useLoginModalStore } from '@/stores/loginModalStore';
 import { Button } from '@/components/common/button/Button';
-import { useObservationRecentQuery } from '@/hooks/queries/observations/useObservation';
+import {
+  useObservationRecentQuery,
+  useObservationDeleteMutation,
+} from '@/hooks/queries/observations/useObservation';
+import { useQueryClient } from '@tanstack/react-query';
+import { MoreButton } from '@/components/common/more-button/MoreButton';
 
 interface NavMenuProps {
   isOpen: boolean;
@@ -33,6 +38,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
   const pathname = usePathname() ?? '';
   const user = useUser();
   const openLoginModal = useLoginModalStore((state) => state.open);
+  const queryClient = useQueryClient();
 
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(
@@ -43,6 +49,12 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
   const toggleSection = (href: string) => {
     setOpenSections((prev) => ({ ...prev, [href]: !prev[href] }));
   };
+
+  const { mutate: deleteObservation } = useObservationDeleteMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['observations', 'recent'] });
+    },
+  });
 
   const { data: recentObservations } = useObservationRecentQuery();
 
@@ -98,15 +110,21 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                             </Link>
                             <ul className="flex flex-col">
                               {recentObservations.map((log) => (
-                                <li key={log.observationId}>
+                                <li
+                                  key={log.observationId}
+                                  className="group relative flex items-center"
+                                >
                                   <Link
                                     href={`/observations/${log.observationId}`}
                                     onClick={onClose}
-                                    className="flex items-center justify-between rounded-lg px-6 py-3.5 text-xs font-medium text-black-700 hover:bg-black-200 md:px-9"
+                                    className="flex-1 truncate px-6 py-3.5 text-xs font-medium text-black-700 hover:rounded-lg hover:bg-black-200 md:px-9"
                                   >
-                                    <span className="truncate">{log.title}</span>
-                                    <MoreDotIcon className="h-4 w-4 shrink-0 text-black-600" />
+                                    {log.title}
                                   </Link>
+                                  <MoreButton
+                                    onDelete={() => deleteObservation(log.observationId)}
+                                    className="absolute top-1/2 right-6 -translate-y-1/2 md:right-9"
+                                  />
                                 </li>
                               ))}
                             </ul>

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -5,35 +5,28 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/utils/cn';
-import { ChevronDownIcon } from '@/app/assets/icons';
+import { ChevronDownIcon, MoreDotIcon, PlusIcon } from '@/app/assets/icons';
 import { DefaultAvatar } from '@/app/assets/images';
 import { useUser } from '@/lib/user-context';
 import { useLoginModalStore } from '@/stores/loginModalStore';
 import { Button } from '@/components/common/button/Button';
+import { useObservationRecentQuery } from '@/hooks/queries/observations/useObservation';
 
 interface NavMenuProps {
   isOpen: boolean;
   onLogout: () => void;
 }
 
-const NAV_SECTIONS = [
-  {
-    href: '/observations',
-    label: 'AI 관찰일지',
-    children: [
-      { label: '새 관찰일지', href: '/observations' },
-      { label: '관찰일지 목록 보기', href: '/mypage/observations' },
-    ],
-  },
-  {
-    href: '/community',
-    label: '커뮤니티',
-    children: [
-      { label: '모아방', href: '/community/moabang' },
-      { label: '자유게시판', href: '/community/board' },
-    ],
-  },
-];
+const COMMUNITY_SECTION = {
+  href: '/community',
+  label: '커뮤니티',
+  children: [
+    { label: '모아방', href: '/community/moabang' },
+    { label: '자유게시판', href: '/community/board' },
+  ],
+};
+
+const NAV_SECTIONS = [{ href: '/observations', label: 'AI 관찰일지' }, COMMUNITY_SECTION];
 
 export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
   const pathname = usePathname() ?? '';
@@ -50,6 +43,8 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
     setOpenSections((prev) => ({ ...prev, [href]: !prev[href] }));
   };
 
+  const { data: recentObservations } = useObservationRecentQuery();
+
   return (
     <div
       className={cn(
@@ -61,21 +56,16 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
       <nav className="flex min-h-[calc(100vh-3rem)] flex-col justify-between">
         <div>
           {NAV_SECTIONS.map((section) => {
-            const isSectionActive =
-              pathname === section.href || pathname.startsWith(section.href + '/');
             const isSectionOpen = openSections[section.href];
+            const isObservation = section.href === '/observations';
 
             return (
               <div key={section.href}>
                 <button
                   onClick={() => toggleSection(section.href)}
-                  className="flex w-full items-center justify-between px-4 py-3.75 text-base font-medium md:px-9"
+                  className="flex w-full items-center justify-between px-4 py-3.75 text-base font-semibold md:px-9"
                 >
-                  <span
-                    className={cn(isSectionActive ? 'font-semibold text-pink-500' : 'text-black')}
-                  >
-                    {section.label}
-                  </span>
+                  <span className="text-black">{section.label}</span>
                   <ChevronDownIcon
                     className={cn(
                       'h-4 w-4 text-black transition-transform',
@@ -85,24 +75,55 @@ export default function NavMenu({ isOpen, onLogout }: NavMenuProps) {
                 </button>
 
                 {isSectionOpen && (
-                  <ul className="flex flex-col pb-2">
-                    {section.children.map((child) => {
-                      const isActive = pathname === child.href;
-                      return (
-                        <li key={child.href}>
-                          <Link
-                            href={child.href}
-                            className={cn(
-                              'block px-8 py-3 text-sm leading-[140%] tracking-[-0.02em]',
-                              isActive ? 'font-semibold text-pink-500' : 'font-medium text-black',
-                            )}
-                          >
-                            {child.label}
-                          </Link>
-                        </li>
-                      );
-                    })}
-                  </ul>
+                  <div className="pb-2">
+                    {isObservation ? (
+                      <div className="bg-black-100 py-2.5">
+                        <Link
+                          href="/observations"
+                          className="flex items-center gap-0.5 px-6 py-3.5 text-xs font-semibold text-black md:px-9"
+                        >
+                          <PlusIcon className="h-4 w-4 shrink-0" />새 관찰일지
+                        </Link>
+                        {recentObservations && recentObservations.length > 0 && (
+                          <>
+                            <Link
+                              href="/mypage/observations"
+                              className="flex items-center gap-2 px-6 py-3 text-xs font-semibold text-black md:px-9"
+                            >
+                              최근 관찰일지
+                              <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />
+                            </Link>
+                            <ul className="flex flex-col">
+                              {recentObservations.map((log) => (
+                                <li key={log.observationId}>
+                                  <Link
+                                    href={`/observations/${log.observationId}`}
+                                    className="flex items-center justify-between px-6 py-3.5 text-xs font-medium text-black-700 md:px-9"
+                                  >
+                                    <span className="truncate">{log.title}</span>
+                                    <MoreDotIcon className="h-4 w-4 shrink-0 text-black-600" />
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          </>
+                        )}
+                      </div>
+                    ) : (
+                      <ul className="flex flex-col bg-black-100 py-2.5">
+                        {COMMUNITY_SECTION.children.map((child) => (
+                          <li key={child.href}>
+                            <Link
+                              href={child.href}
+                              className="block px-6 py-3.5 text-xs font-semibold text-black md:px-9"
+                            >
+                              {child.label}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                 )}
               </div>
             );

--- a/components/common/sidebar/Sidebar.tsx
+++ b/components/common/sidebar/Sidebar.tsx
@@ -22,7 +22,10 @@ export default function Sidebar() {
   }
 
   return (
-    <aside className="h-full w-89.25 border-r border-black-200" aria-label="사이드 내비게이션">
+    <aside
+      className="hidden h-full w-89.25 border-r border-black-200 xl:block"
+      aria-label="사이드 내비게이션"
+    >
       <div className="flex h-full flex-col justify-between">
         {sidebarConfig.sections.map((section) => (
           <nav key={section.ariaLabel} aria-label={section.ariaLabel}>

--- a/components/observations/ObservationSidebar.tsx
+++ b/components/observations/ObservationSidebar.tsx
@@ -8,7 +8,7 @@ export default async function ObservationSidebar() {
 
   return (
     <aside
-      className={`relative flex h-full flex-col border-r border-black-200 bg-white transition-all duration-300 ${isOpen ? 'w-89.25' : 'w-20'}`}
+      className={`relative hidden h-full flex-col border-r border-black-200 bg-white transition-all duration-300 xl:flex ${isOpen ? 'w-89.25' : 'w-20'}`}
       aria-label="AI 관찰일지 사이드바"
     >
       <ObservationSidebarToggle isOpen={isOpen} />

--- a/hooks/queries/observations/useObservation.ts
+++ b/hooks/queries/observations/useObservation.ts
@@ -1,5 +1,6 @@
 import {
   useInfiniteQuery,
+  useQuery,
   useMutation,
   UseMutationOptions,
   useSuspenseQuery,
@@ -16,6 +17,14 @@ import {
   ObservationCreateResponse,
   ObservationDetailResponse,
 } from '@/types/observation.type';
+
+export const useObservationRecentQuery = () => {
+  return useQuery({
+    queryKey: ['observations', 'recent'],
+    queryFn: () => getObservations(),
+    select: (data) => data.items.slice(0, 4),
+  });
+};
 
 export const useObservationListQuery = () => {
   return useInfiniteQuery({


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 모바일/태블릿 환경에서 사이드바를 대체할 네비게이션 메뉴 필요

- ## 주요 변경(무엇을?):
  - xl 미만 화면에서 햄버거 메뉴를 통해 전체 네비게이션 접근 가능하도록 구현 

## 변경 내용

- [x] xl 미만 화면에서 사이드바 숨김 처리
- [x] Header 반응형 햄버거 버튼 추가
- [x] NavMenu 컴포넌트 구현
  - 아코디언 메뉴
  - 최근 관찰일지 목록
  - 프로필 카드
  - 로그인/로그아웃
- [x] 최근 관찰일지 삭제 기능 연동

### 세부 변경 사항

- HamburgerIcon SVG 추가
- XIcon, MainLogoIcon SVG 고정 크기 제거
- NavMenu 구성
  - AI 관찰일지
    - 새 관찰일지
    - 최근 관찰일지 4개 표시
    - 최근 관찰일지 삭제 및 이동 기능
  - 커뮤니티
    - 모아방
    - 자유게시판
- 링크 클릭 시 NavMenu 자동 닫힘 처리
- NavMenu 호버 스타일 추가
- 로그인/로그아웃 상태 연동
- MoreButton 드롭다운 z-index 수정

## 스크린샷/동영상 (선택)
- 모바일
  <img width="320" height="660" alt="스크린샷 2026-05-16 오전 6 25 13" src="https://github.com/user-attachments/assets/10d9cc2d-d45c-4bc4-8873-616b8232c1af" />

- 태블릿
  <img width="573" height="824" alt="스크린샷 2026-05-16 오전 6 25 46" src="https://github.com/user-attachments/assets/1b99f7e7-01ba-4873-9433-45fd4d885704" />


## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #88
