### PR TITLE
Feature: 공통 BottomSheet 컴포넌트 구현 (#90)

### DIFF
--- a/components/common/bottom-sheet/BottomSheet.stories.tsx
+++ b/components/common/bottom-sheet/BottomSheet.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+import { SelectBottomSheet } from './SelectBottomSheet';
+
+const OPTIONS_AGE = [
+  { label: '만 0세', value: '0' },
+  { label: '만 1세', value: '1' },
+  { label: '만 2세', value: '2' },
+  { label: '만 3세', value: '3' },
+  { label: '만 4세', value: '4' },
+  { label: '만 5세', value: '5' },
+];
+
+const OPTIONS_DEVELOPMENT = [
+  { label: '신체운동·건강', value: 'physical' },
+  { label: '의사소통', value: 'communication' },
+  { label: '사회관계', value: 'social' },
+  { label: '예술경험', value: 'art' },
+  { label: '자연탐구', value: 'nature' },
+];
+
+const meta: Meta<typeof SelectBottomSheet> = {
+  title: 'Common/BottomSheet',
+  component: SelectBottomSheet,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SelectBottomSheet>;
+
+export const SingleSelect: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    const [value, setValue] = useState('');
+    return (
+      <SelectBottomSheet
+        open={open}
+        onOpenChange={setOpen}
+        title="연령"
+        options={OPTIONS_AGE}
+        value={value}
+        onChange={setValue}
+        onConfirm={() => setOpen(false)}
+      />
+    );
+  },
+};
+
+export const MultiSelect: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <SelectBottomSheet
+        multiple
+        open={open}
+        onOpenChange={setOpen}
+        title="5개 영역"
+        description="중복선택 가능"
+        options={OPTIONS_DEVELOPMENT}
+        value={value}
+        onChange={setValue}
+        onConfirm={() => setOpen(false)}
+      />
+    );
+  },
+};

--- a/components/common/bottom-sheet/BottomSheet.tsx
+++ b/components/common/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { XIcon } from '@/app/assets/icons';
+import { cn } from '@/utils/cn';
+
+interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+}: BottomSheetProps) {
+  return (
+    <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="overlay fixed inset-0 z-900" />
+        <RadixDialog.Content
+          className={cn(
+            'fixed right-0 bottom-0 left-0 z-1000',
+            'flex flex-col rounded-t-[20px] bg-white',
+            'focus:outline-none',
+          )}
+        >
+          <div className="flex items-center justify-between px-4 py-5">
+            <div className="flex items-center gap-2">
+              <RadixDialog.Title className="text-[15px] font-semibold text-black-800">
+                {title}
+              </RadixDialog.Title>
+              {description && (
+                <RadixDialog.Description className="text-[13px] font-medium text-black-500">
+                  {description}
+                </RadixDialog.Description>
+              )}
+            </div>
+            <RadixDialog.Close className="cursor-pointer text-black-500 outline-none focus-visible:ring-2 focus-visible:ring-black-400">
+              <XIcon width={20} height={20} />
+            </RadixDialog.Close>
+          </div>
+          {children}
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+}

--- a/components/common/bottom-sheet/BottomSheet.tsx
+++ b/components/common/bottom-sheet/BottomSheet.tsx
@@ -3,14 +3,7 @@
 import * as RadixDialog from '@radix-ui/react-dialog';
 import { XIcon } from '@/app/assets/icons';
 import { cn } from '@/utils/cn';
-
-interface BottomSheetProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}
+import type { BottomSheetProps } from './bottom-sheet.type';
 
 export function BottomSheet({
   open,

--- a/components/common/bottom-sheet/BottomSheet.tsx
+++ b/components/common/bottom-sheet/BottomSheet.tsx
@@ -23,7 +23,7 @@ export function BottomSheet({
             'focus:outline-none',
           )}
         >
-          <div className="flex items-center justify-between px-4 py-5">
+          <div className="flex items-center justify-between border-b border-black-200 px-4 py-5">
             <div className="flex items-center gap-2">
               <RadixDialog.Title className="text-[15px] font-semibold text-black-800">
                 {title}

--- a/components/common/bottom-sheet/SelectBottomSheet.tsx
+++ b/components/common/bottom-sheet/SelectBottomSheet.tsx
@@ -4,30 +4,7 @@ import { CheckIcon } from '@/app/assets/icons';
 import { Button } from '@/components/common/button/Button';
 import { cn } from '@/utils/cn';
 import { BottomSheet } from './BottomSheet';
-import type { SelectOption } from '@/components/common/select/select.type';
-
-interface SelectBottomSheetSharedProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  title: string;
-  description?: string;
-  options: SelectOption[];
-  onConfirm: () => void;
-}
-
-interface SingleSelectBottomSheetProps extends SelectBottomSheetSharedProps {
-  multiple?: false;
-  value?: string;
-  onChange?: (value: string) => void;
-}
-
-interface MultiSelectBottomSheetProps extends SelectBottomSheetSharedProps {
-  multiple: true;
-  value?: string[];
-  onChange?: (value: string[]) => void;
-}
-
-type SelectBottomSheetProps = SingleSelectBottomSheetProps | MultiSelectBottomSheetProps;
+import type { SelectBottomSheetProps } from './bottom-sheet.type';
 
 export function SelectBottomSheet(props: SelectBottomSheetProps) {
   const { open, onOpenChange, title, description, options, onConfirm } = props;

--- a/components/common/bottom-sheet/SelectBottomSheet.tsx
+++ b/components/common/bottom-sheet/SelectBottomSheet.tsx
@@ -28,7 +28,7 @@ export function SelectBottomSheet(props: SelectBottomSheetProps) {
 
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange} title={title} description={description}>
-      <ul className="overflow-y-auto">
+      <ul className="max-h-[50vh] overflow-y-auto">
         {options.map((option) => {
           const selected = isSelected(option.value);
           return (

--- a/components/common/bottom-sheet/SelectBottomSheet.tsx
+++ b/components/common/bottom-sheet/SelectBottomSheet.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { CheckIcon } from '@/app/assets/icons';
+import { Button } from '@/components/common/button/Button';
+import { cn } from '@/utils/cn';
+import { BottomSheet } from './BottomSheet';
+import type { SelectOption } from '@/components/common/select/select.type';
+
+interface SelectBottomSheetSharedProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  options: SelectOption[];
+  onConfirm: () => void;
+}
+
+interface SingleSelectBottomSheetProps extends SelectBottomSheetSharedProps {
+  multiple?: false;
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+interface MultiSelectBottomSheetProps extends SelectBottomSheetSharedProps {
+  multiple: true;
+  value?: string[];
+  onChange?: (value: string[]) => void;
+}
+
+type SelectBottomSheetProps = SingleSelectBottomSheetProps | MultiSelectBottomSheetProps;
+
+export function SelectBottomSheet(props: SelectBottomSheetProps) {
+  const { open, onOpenChange, title, description, options, onConfirm } = props;
+
+  function isSelected(optionValue: string): boolean {
+    if (props.multiple) return (props.value ?? []).includes(optionValue);
+    return props.value === optionValue;
+  }
+
+  function handleOptionClick(optionValue: string) {
+    if (props.multiple) {
+      const current = props.value ?? [];
+      const next = current.includes(optionValue)
+        ? current.filter((v) => v !== optionValue)
+        : [...current, optionValue];
+      props.onChange?.(next);
+    } else {
+      props.onChange?.(optionValue);
+    }
+  }
+
+  return (
+    <BottomSheet open={open} onOpenChange={onOpenChange} title={title} description={description}>
+      <ul className="overflow-y-auto">
+        {options.map((option) => {
+          const selected = isSelected(option.value);
+          return (
+            <li key={option.value}>
+              <button
+                type="button"
+                onClick={() => handleOptionClick(option.value)}
+                className={cn(
+                  'flex w-full cursor-pointer items-center justify-between px-4 py-4 text-sm font-medium text-black-700 transition-colors',
+                  selected ? 'bg-black-200' : 'bg-white',
+                )}
+              >
+                <span>{option.label}</span>
+                {selected && <CheckIcon width={20} height={20} className="shrink-0" />}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="px-4 py-5">
+        <Button size="full" className="py-4" onClick={onConfirm}>
+          확인
+        </Button>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/components/common/bottom-sheet/bottom-sheet.type.ts
+++ b/components/common/bottom-sheet/bottom-sheet.type.ts
@@ -1,0 +1,32 @@
+import type { SelectOption } from '@/components/common/select/select.type';
+
+export interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+interface SelectBottomSheetSharedProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  options: SelectOption[];
+  onConfirm: () => void;
+}
+
+interface SingleSelectBottomSheetProps extends SelectBottomSheetSharedProps {
+  multiple?: false;
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+interface MultiSelectBottomSheetProps extends SelectBottomSheetSharedProps {
+  multiple: true;
+  value?: string[];
+  onChange?: (value: string[]) => void;
+}
+
+export type SelectBottomSheetProps = SingleSelectBottomSheetProps | MultiSelectBottomSheetProps;

--- a/components/common/bottom-sheet/index.ts
+++ b/components/common/bottom-sheet/index.ts
@@ -1,0 +1,3 @@
+export { BottomSheet } from './BottomSheet';
+export { SelectBottomSheet } from './SelectBottomSheet';
+export type { BottomSheetProps, SelectBottomSheetProps } from './bottom-sheet.type';


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 재사용 가능한 공통 BottomSheet 컴포넌트를 구현

- ## 주요 변경(무엇을?):
  - BottomSheet 컴포넌트 구현
  - SelectBottomSheet 컴포넌트 구현 (단일/다중 선택)

## 변경 내용

- [x] BottomSheet 공통 컴포넌트 추가 (`@radix-ui/react-dialog`)
- [x] SelectBottomSheet 컴포넌트 추가 (단일/다중 선택)

### 세부 변경 사항

- `BottomSheet`: backdrop, 헤더(제목/설명/닫기 버튼), children 슬롯으로 구성된 공통 래퍼
- `SelectBottomSheet`: `BottomSheet` 기반으로 옵션 목록과 확인 버튼을 포함한 선택 전용 컴포넌트
- `bottom-sheet.type.ts`: BottomSheet 관련 타입 분리
- `index.ts`: 배럴 export 추가
- `BottomSheet.stories.tsx`: 단일/다중 선택 스토리 추가
- 추후 다른 디자인의 바텀시트가 필요한 경우, `BottomSheet` 컴포넌트를 기반으로 확장하여 사용 가능

## 스크린샷/동영상 (선택)
- 단일 선택
  <img width="304" height="656" alt="스크린샷 2026-05-16 오후 3 39 17" src="https://github.com/user-attachments/assets/db150565-9341-4af7-9e06-6bd83f80b4f8" />

- 다중 선택
  <img width="304" height="656" alt="스크린샷 2026-05-16 오후 3 39 57" src="https://github.com/user-attachments/assets/acb8c669-92dd-4d5d-b69e-45619e0a9fe2" />


## 테스트

- [ ] 유닛 테스트 추가/수정됨
- [ ] 로컬에서 `pnpm test` 통과
- [ ] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bottom sheet component for displaying options and selections in a mobile-friendly modal
  * Supports both single and multi-select modes with confirmation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->