### PR TITLE
Style: AI 관찰일지 페이지 반응형 UI 구현 (#92)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,17 @@ html {
   animation: blink 1s step-end infinite;
 }
 
+.animate-lift {
+  transition:
+    box-shadow 200ms,
+    transform 200ms;
+}
+
+.animate-lift:hover {
+  transform: translateY(-0.125rem);
+  box-shadow: 2px 8px 40px 0px #00000008;
+}
+
 .typo-line-m2 {
   line-height: 140%;
   letter-spacing: -0.02em;

--- a/app/observations/[id]/page.tsx
+++ b/app/observations/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import ObservationBoundary from '@/components/observations/ObservationBoundary';
+import ObservationDetailBoundary from '@/components/observations/ObservationDetailBoundary';
 
 interface ObservationDetailPageProps {
   params: Promise<{ id: string }>;
@@ -11,5 +11,5 @@ export default async function ObservationDetailPage({ params }: ObservationDetai
 
   if (Number.isNaN(observationId) || observationId <= 0) notFound();
 
-  return <ObservationBoundary observationId={observationId} />;
+  return <ObservationDetailBoundary observationId={observationId} />;
 }

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -12,7 +12,7 @@ export default function ObservationsLayout({ children }: { children: React.React
             <ObservationCreditBadgeWrapper />
           </Suspense>
         </div>
-        <div className="px-20 pt-25 pb-15">{children}</div>
+        <div className="px-3.75 pt-16 md:px-8 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
       </div>
     </div>
   );

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -9,7 +9,7 @@ export default function ObservationsLayout({ children }: { children: React.React
         <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-5 md:right-8 md:left-auto md:translate-x-0 xl:top-6 xl:right-20">
           <ObservationCreditBadgeWrapper />
         </div>
-        <div className="px-4 pt-16 md:px-9 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
+        <div className="px-4 py-16 md:px-9 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
       </div>
     </div>
   );

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -1,10 +1,19 @@
+import { Suspense } from 'react';
 import ObservationSidebar from '@/components/observations/ObservationSidebar';
+import { ObservationCreditBadgeWrapper } from '@/components/observations/ObservationCreditBadgeWrapper';
 
 export default function ObservationsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full">
       <ObservationSidebar />
-      <div className="flex-1 overflow-y-auto px-20 pt-25 pb-15">{children}</div>
+      <div className="relative flex-1 overflow-y-auto px-20 pt-25 pb-15">
+        <div className="absolute top-6 right-20">
+          <Suspense>
+            <ObservationCreditBadgeWrapper />
+          </Suspense>
+        </div>
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import ObservationSidebar from '@/components/observations/ObservationSidebar';
 import { ObservationCreditBadgeWrapper } from '@/components/observations/ObservationCreditBadgeWrapper';
 
@@ -8,9 +7,7 @@ export default function ObservationsLayout({ children }: { children: React.React
       <ObservationSidebar />
       <div className="relative flex-1 overflow-y-auto">
         <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-5 md:right-8 md:left-auto md:translate-x-0 xl:top-6 xl:right-20">
-          <Suspense>
-            <ObservationCreditBadgeWrapper />
-          </Suspense>
+          <ObservationCreditBadgeWrapper />
         </div>
         <div className="px-3.75 pt-16 md:px-8 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
       </div>

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -9,7 +9,7 @@ export default function ObservationsLayout({ children }: { children: React.React
         <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-5 md:right-8 md:left-auto md:translate-x-0 xl:top-6 xl:right-20">
           <ObservationCreditBadgeWrapper />
         </div>
-        <div className="px-3.75 pt-16 md:px-8 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
+        <div className="px-4 pt-16 md:px-9 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
       </div>
     </div>
   );

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -6,13 +6,13 @@ export default function ObservationsLayout({ children }: { children: React.React
   return (
     <div className="flex h-full">
       <ObservationSidebar />
-      <div className="relative flex-1 overflow-y-auto px-20 pt-25 pb-15">
-        <div className="absolute top-6 right-20">
+      <div className="relative flex-1 overflow-y-auto">
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-5 md:right-8 md:left-auto md:translate-x-0 xl:top-6 xl:right-20">
           <Suspense>
             <ObservationCreditBadgeWrapper />
           </Suspense>
         </div>
-        {children}
+        <div className="px-20 pt-25 pb-15">{children}</div>
       </div>
     </div>
   );

--- a/app/observations/page.tsx
+++ b/app/observations/page.tsx
@@ -1,5 +1,5 @@
-import ObservationCreateForm from '@/components/observations/ObservationCreateForm';
+import ObservationCreateFormBoundary from '@/components/observations/ObservationCreateFormBoundary';
 
 export default function ObservationsPage() {
-  return <ObservationCreateForm />;
+  return <ObservationCreateFormBoundary />;
 }

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -56,7 +56,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
     },
   });
 
-  const { data: recentObservations } = useObservationRecentQuery();
+  const { data: recentObservations } = useObservationRecentQuery(!!user);
 
   return (
     <div

--- a/components/common/observation-credit-badge/ObservationCreditBadge.tsx
+++ b/components/common/observation-credit-badge/ObservationCreditBadge.tsx
@@ -1,0 +1,17 @@
+import Image from 'next/image';
+import { HeroBadge } from '@/app/assets/images';
+
+interface ObservationCreditBadgeProps {
+  remainingCount: number;
+}
+
+export function ObservationCreditBadge({ remainingCount }: ObservationCreditBadgeProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-[30px] border border-yellow-600 bg-yellow-200 py-1 pr-3 pl-1 shadow-[2px_2px_8px_0px_#00000014]">
+      <Image src={HeroBadge} alt="" width={24} height={24} />
+      <span className="text-xs font-semibold text-black-800">
+        오늘 생성횟수 {remainingCount}개 남았어요!
+      </span>
+    </div>
+  );
+}

--- a/components/common/observation-credit-badge/ObservationCreditBadge.tsx
+++ b/components/common/observation-credit-badge/ObservationCreditBadge.tsx
@@ -8,8 +8,8 @@ interface ObservationCreditBadgeProps {
 export function ObservationCreditBadge({ remainingCount }: ObservationCreditBadgeProps) {
   return (
     <div className="flex items-center gap-2 rounded-[30px] border border-yellow-600 bg-yellow-200 py-1 pr-3 pl-1 shadow-[2px_2px_8px_0px_#00000014]">
-      <Image src={HeroBadge} alt="" width={24} height={24} />
-      <span className="text-xs font-semibold text-black-800">
+      <Image src={HeroBadge} alt="" width={24} height={24} className="shrink-0" />
+      <span className="text-xs font-semibold whitespace-nowrap text-black-800">
         오늘 생성횟수 {remainingCount}개 남았어요!
       </span>
     </div>

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -146,11 +146,11 @@ export default function ObservationCreateForm() {
             />
           </section>
           {selectedTags.length > 0 && (
-            <div className="flex flex-wrap gap-3.5 pt-5">
+            <div className="flex flex-wrap gap-3 pt-5">
               {selectedTags.map((tag) => (
                 <span
                   key={tag.key}
-                  className="flex items-center gap-1.5 p-1.5 text-xs font-medium text-pink-500"
+                  className="flex items-center gap-2.5 rounded-[20px] bg-pink-50 px-3.5 py-2 text-xs font-medium text-pink-500"
                 >
                   {tag.label}
                   <button
@@ -159,7 +159,7 @@ export default function ObservationCreateForm() {
                     aria-label={`${tag.label} 제거`}
                     className="cursor-pointer"
                   >
-                    <XIcon className="text-black-700" />
+                    <XIcon width={20} height={20} className="text-pink-900" />
                   </button>
                 </span>
               ))}

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -93,29 +93,36 @@ export default function ObservationCreateForm() {
         ]}
       />
       <div className="flex flex-col items-center">
-        <div className="mb-12.5 text-center">
-          <h1 className="text-xl font-semibold text-black">관찰일지를 완성해보세요!</h1>
-          <p className="mt-0.5 text-sm font-medium text-black">
+        <div className="mb-5 text-center md:mb-12.5">
+          <h1 className="text-base font-semibold text-black md:text-xl">
+            관찰일지를
+            <br className="md:hidden" />
+            완성해보세요!
+          </h1>
+          <p className="mt-5 text-sm font-medium text-black md:mt-0.5 md:text-sm">
             간단한 입력으로 영유아의 행동을 기록할 수 있어요
           </p>
         </div>
 
-        <h2 className="mb-5 w-full max-w-350 text-lg font-semibold text-black">
+        <h2 className="mb-5 hidden w-full max-w-350 font-semibold text-black md:block md:text-lg">
           관찰일지 맞춤 검색
         </h2>
 
         <div
           className={`w-full max-w-350 rounded-[20px] bg-white px-12.5 pt-11.75 ${selectedTags.length > 0 ? 'pb-5' : 'pb-11.75'}`}
         >
-          <section className="mb-5">
-            <h2 className="mb-5 text-lg font-semibold text-black-800">기본정보</h2>
-            <div className="flex gap-15">
+          <section className="mb-12.5 xl:mb-5">
+            <h2 className="mb-1.5 text-base font-semibold text-black-800 md:mb-5 md:text-lg">
+              기본정보
+            </h2>
+            <div className="flex flex-col gap-5 md:flex-row md:gap-15">
               <Select
                 size="md"
                 options={AGE_OPTIONS}
                 triggerLabel="연령"
                 value={age}
                 onChange={setAge}
+                className="w-full md:w-90"
               />
               <Select
                 multiple
@@ -124,20 +131,25 @@ export default function ObservationCreateForm() {
                 triggerLabel="5개 영역"
                 value={areas}
                 onChange={setAreas}
+                className="w-full md:w-90"
               />
             </div>
           </section>
 
           <section>
-            <h2 className="mb-5 text-lg font-semibold text-black-800">관찰상황 입력</h2>
+            <h2 className="mb-1.5 text-base font-semibold text-black-800 md:mb-5 md:text-lg">
+              관찰상황 입력
+            </h2>
             <Textarea
               placeholder="영유아의 행동이나 상황을 구체적인 문장으로 입력해주세요"
               value={content}
               onChange={(e) => setContent(e.target.value)}
+              className="text-[14px] md:text-sm"
               action={
                 <Button
-                  size="md"
+                  size="sm"
                   onClick={handleSubmit}
+                  className="md:w-35 md:py-2 md:text-base"
                   disabled={!isFormValid || isMutating || isPending}
                 >
                   생성하기
@@ -150,7 +162,7 @@ export default function ObservationCreateForm() {
               {selectedTags.map((tag) => (
                 <span
                   key={tag.key}
-                  className="flex items-center gap-2.5 rounded-[20px] bg-pink-50 px-3.5 py-2 text-xs font-medium text-pink-500"
+                  className="flex items-center gap-px rounded-[20px] bg-pink-50 px-2.5 py-1 text-xs font-medium text-pink-500 md:gap-2.5 md:px-3.5 md:py-2"
                 >
                   {tag.label}
                   <button
@@ -159,7 +171,8 @@ export default function ObservationCreateForm() {
                     aria-label={`${tag.label} 제거`}
                     className="cursor-pointer"
                   >
-                    <XIcon width={20} height={20} className="text-pink-900" />
+                    <XIcon width={18} height={18} className="text-pink-900 md:hidden" />
+                    <XIcon width={20} height={20} className="hidden text-pink-900 md:block" />
                   </button>
                 </span>
               ))}

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -4,8 +4,9 @@ import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { XIcon } from '@/app/assets/icons';
+import { XIcon, ChevronDownIcon } from '@/app/assets/icons';
 import { Select } from '@/components/common/select/Select';
+import { SelectBottomSheet } from '@/components/common/bottom-sheet/SelectBottomSheet';
 import { Textarea } from '@/components/common/textarea/Textarea';
 import { Button } from '@/components/common/button/Button';
 import { Dialog } from '@/components/common/dialog/Dialog';
@@ -16,6 +17,7 @@ import {
   SECTION_TYPE_LABEL,
 } from '@/constants/observations/observation';
 import { useObservationMutation } from '@/hooks/queries/observations/useObservation';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { toast } from '@/utils/toast';
 
 export default function ObservationCreateForm() {
@@ -27,6 +29,10 @@ export default function ObservationCreateForm() {
 
   const [isPending, startTransition] = useTransition();
   const [showCreditDialog, setShowCreditDialog] = useState(false);
+  const [ageBottomSheetOpen, setAgeBottomSheetOpen] = useState(false);
+  const [areaBottomSheetOpen, setAreaBottomSheetOpen] = useState(false);
+
+  const isMobile = useIsMobile();
 
   const { mutate: createObservation, isPending: isMutating } = useObservationMutation({
     onSuccess: ({ observationId }) => {
@@ -116,23 +122,66 @@ export default function ObservationCreateForm() {
               기본정보
             </h2>
             <div className="flex flex-col gap-5 md:flex-row md:gap-15">
-              <Select
-                size="md"
-                options={AGE_OPTIONS}
-                triggerLabel="연령"
-                value={age}
-                onChange={setAge}
-                className="w-full md:w-90"
-              />
-              <Select
-                multiple
-                size="md"
-                options={AREA_OPTIONS}
-                triggerLabel="5개 영역"
-                value={areas}
-                onChange={setAreas}
-                className="w-full md:w-90"
-              />
+              {isMobile ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setAgeBottomSheetOpen(true)}
+                    className="flex w-full items-center justify-between rounded-lg border border-black-300 p-2.5 text-sm font-medium text-black-800"
+                  >
+                    <span>연령</span>
+                    <ChevronDownIcon width={20} height={20} className="shrink-0" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setAreaBottomSheetOpen(true)}
+                    className="flex w-full items-center justify-between rounded-lg border border-black-300 p-2.5 text-sm font-medium text-black-800"
+                  >
+                    <span>5개 영역</span>
+                    <ChevronDownIcon width={20} height={20} className="shrink-0" />
+                  </button>
+                  <SelectBottomSheet
+                    open={ageBottomSheetOpen}
+                    onOpenChange={setAgeBottomSheetOpen}
+                    title="연령"
+                    options={AGE_OPTIONS}
+                    value={age}
+                    onChange={setAge}
+                    onConfirm={() => setAgeBottomSheetOpen(false)}
+                  />
+                  <SelectBottomSheet
+                    multiple
+                    open={areaBottomSheetOpen}
+                    onOpenChange={setAreaBottomSheetOpen}
+                    title="5개 영역"
+                    description="중복선택 가능"
+                    options={AREA_OPTIONS}
+                    value={areas}
+                    onChange={setAreas}
+                    onConfirm={() => setAreaBottomSheetOpen(false)}
+                  />
+                </>
+              ) : (
+                <>
+                  <Select
+                    size="md"
+                    options={AGE_OPTIONS}
+                    triggerLabel="연령"
+                    value={age}
+                    onChange={setAge}
+                    className="w-full md:w-90"
+                  />
+                  <Select
+                    multiple
+                    size="md"
+                    options={AREA_OPTIONS}
+                    triggerLabel="5개 영역"
+                    value={areas}
+                    onChange={setAreas}
+                    className="w-full md:w-90"
+                  />
+                </>
+              )}
             </div>
           </section>
 

--- a/components/observations/ObservationCreateFormBoundary.tsx
+++ b/components/observations/ObservationCreateFormBoundary.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import ObservationCreateForm from './ObservationCreateForm';
+
+export default function ObservationCreateFormBoundary() {
+  return (
+    <AsyncBoundary
+      pendingFallback={<LoadingSpinner className="h-full justify-center" />}
+      rejectedFallback={({ error, reset }) => (
+        <ErrorFallback error={error} actionLabel="다시 시도" onAction={reset} />
+      )}
+    >
+      <ObservationCreateForm />
+    </AsyncBoundary>
+  );
+}

--- a/components/observations/ObservationCreditBadgeWrapper.tsx
+++ b/components/observations/ObservationCreditBadgeWrapper.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { ObservationCreditBadge } from '@/components/common/observation-credit-badge/ObservationCreditBadge';
+import { useCreditsQuery } from '@/hooks/queries/user/useCredits';
+
+export function ObservationCreditBadgeWrapper() {
+  const { data: credits } = useCreditsQuery();
+
+  return <ObservationCreditBadge remainingCount={credits?.balance ?? 0} />;
+}

--- a/components/observations/ObservationCreditBadgeWrapper.tsx
+++ b/components/observations/ObservationCreditBadgeWrapper.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { ObservationCreditBadge } from '@/components/common/observation-credit-badge/ObservationCreditBadge';
 import { useCreditsQuery } from '@/hooks/queries/user/useCredits';
 
 export function ObservationCreditBadgeWrapper() {
+  const pathname = usePathname();
   const { data: credits } = useCreditsQuery();
+
+  if (pathname !== '/observations') return null;
 
   return <ObservationCreditBadge remainingCount={credits?.balance ?? 0} />;
 }

--- a/components/observations/ObservationDetail.tsx
+++ b/components/observations/ObservationDetail.tsx
@@ -73,7 +73,7 @@ export default function ObservationDetail({ observationId }: ObservationDetailPr
             <ObservationResultCard key={item.title} title={item.title} content={item.content} />
           ))}
         </div>
-        <div className="flex justify-end pt-3.5 md:pt-15">
+        <div className="flex justify-end pt-4 md:pt-15">
           <Button
             size="sm"
             className="md:w-35 md:py-2 md:text-base"

--- a/components/observations/ObservationDetail.tsx
+++ b/components/observations/ObservationDetail.tsx
@@ -73,8 +73,12 @@ export default function ObservationDetail({ observationId }: ObservationDetailPr
             <ObservationResultCard key={item.title} title={item.title} content={item.content} />
           ))}
         </div>
-        <div className="flex justify-end pt-15">
-          <Button size="md" onClick={() => regenerate(observationId)}>
+        <div className="flex justify-end pt-3.5 md:pt-15">
+          <Button
+            size="sm"
+            className="md:w-35 md:py-2 md:text-base"
+            onClick={() => regenerate(observationId)}
+          >
             재생성
           </Button>
         </div>

--- a/components/observations/ObservationDetailBoundary.tsx
+++ b/components/observations/ObservationDetailBoundary.tsx
@@ -3,11 +3,13 @@
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
 import ObservationDetail from './ObservationDetail';
 
-interface ObservationBoundaryProps {
+interface ObservationDetailBoundaryProps {
   observationId: number;
 }
 
-export default function ObservationBoundary({ observationId }: ObservationBoundaryProps) {
+export default function ObservationDetailBoundary({
+  observationId,
+}: ObservationDetailBoundaryProps) {
   return (
     <AsyncBoundary
       pendingFallback={<LoadingSpinner className="h-full justify-center" />}

--- a/components/observations/ObservationLoading.tsx
+++ b/components/observations/ObservationLoading.tsx
@@ -4,7 +4,7 @@ import Spinner from '@/components/common/spinner/Spinner';
 
 export default function ObservationLoading() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-5">
+    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-5 bg-black-100">
       <Image src={observationMascot} alt="관찰일지 로딩 캐릭터" width={121} height={130} />
       <div className="flex flex-col items-center gap-0.5 text-center text-black">
         <p className="text-xl font-semibold">관찰일지를 준비하고 있어요</p>

--- a/components/observations/ObservationLoading.tsx
+++ b/components/observations/ObservationLoading.tsx
@@ -4,7 +4,7 @@ import Spinner from '@/components/common/spinner/Spinner';
 
 export default function ObservationLoading() {
   return (
-    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-5 bg-black-100">
+    <div className="absolute inset-0 z-900 flex flex-col items-center justify-center gap-5 bg-black-100">
       <Image src={observationMascot} alt="관찰일지 로딩 캐릭터" width={121} height={130} />
       <div className="flex flex-col items-center gap-0.5 text-center text-black">
         <p className="text-xl font-semibold">관찰일지를 준비하고 있어요</p>

--- a/components/observations/ObservationResultCard.tsx
+++ b/components/observations/ObservationResultCard.tsx
@@ -20,7 +20,7 @@ export default function ObservationResultCard({ title, content }: ObservationRes
   };
 
   return (
-    <div className="flex flex-col rounded-2xl bg-white px-5 py-2.25 md:px-7.5 md:py-2.5 xl:px-15 xl:pt-[25.5px] xl:pb-[15.5px]">
+    <div className="animate-lift flex flex-col rounded-2xl bg-white px-5 py-2.25 md:px-7.5 md:py-2.5 xl:px-15 xl:pt-[25.5px] xl:pb-[15.5px]">
       <p className="border-b-[0.5px] border-b-black-400 pb-5 text-sm font-semibold text-pink-500 md:text-base">
         {title}
       </p>

--- a/components/observations/ObservationResultCard.tsx
+++ b/components/observations/ObservationResultCard.tsx
@@ -31,7 +31,7 @@ export default function ObservationResultCard({ title, content }: ObservationRes
           size="sm"
           onClick={handleCopy}
           aria-label="복사"
-          className="flex w-auto items-center gap-1"
+          className="flex w-auto items-center gap-1 text-xs md:text-sm"
         >
           <CopyIcon />
           복사

--- a/components/observations/ObservationResultCard.tsx
+++ b/components/observations/ObservationResultCard.tsx
@@ -20,12 +20,12 @@ export default function ObservationResultCard({ title, content }: ObservationRes
   };
 
   return (
-    <div className="flex flex-col rounded-2xl bg-white px-15 pt-[25.5px] pb-[15.5px]">
-      <p className="border-b-[0.5px] border-b-black-400 pb-5 text-base font-semibold text-pink-500">
+    <div className="flex flex-col rounded-2xl bg-white px-5 py-2.25 md:px-7.5 md:py-2.5 xl:px-15 xl:pt-[25.5px] xl:pb-[15.5px]">
+      <p className="border-b-[0.5px] border-b-black-400 pb-5 text-sm font-semibold text-pink-500 md:text-base">
         {title}
       </p>
       <p className="mt-5 text-sm font-medium text-black">{content}</p>
-      <div className="mt-7.5 flex justify-end">
+      <div className="mt-2.5 flex justify-end md:mt-7.5">
         <Button
           variant="ghost"
           size="sm"

--- a/hooks/queries/observations/useObservation.ts
+++ b/hooks/queries/observations/useObservation.ts
@@ -18,16 +18,16 @@ import {
   ObservationDetailResponse,
 } from '@/types/observation.type';
 
-export const useObservationRecentQuery = (enabled = true) => {
+export function useObservationRecentQuery(enabled = true) {
   return useQuery({
     queryKey: ['observations', 'recent'],
     queryFn: () => getObservations(),
     select: (data) => data.items.slice(0, 4),
     enabled,
   });
-};
+}
 
-export const useObservationListQuery = () => {
+export function useObservationListQuery() {
   return useInfiniteQuery({
     queryKey: ['observations'],
     queryFn: ({ pageParam }) => getObservations(pageParam),
@@ -35,36 +35,36 @@ export const useObservationListQuery = () => {
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
   });
-};
+}
 
-export const useObservationItemQuery = (id: number) => {
+export function useObservationItemQuery(id: number) {
   return useSuspenseQuery({
     queryKey: ['observation', id],
     queryFn: () => getObservation(id),
   });
-};
+}
 
-export const useObservationMutation = (
+export function useObservationMutation(
   options?: UseMutationOptions<ObservationCreateResponse, Error, ObservationCreateRequest>,
-) => {
+) {
   return useMutation({
     mutationFn: createObservation,
     ...options,
   });
-};
+}
 
-export const useObservationRegenerateMutation = (
+export function useObservationRegenerateMutation(
   options?: UseMutationOptions<ObservationDetailResponse, Error, number>,
-) => {
+) {
   return useMutation({
     mutationFn: regenerateObservation,
     ...options,
   });
-};
+}
 
-export const useObservationDeleteMutation = (options?: UseMutationOptions<void, Error, number>) => {
+export function useObservationDeleteMutation(options?: UseMutationOptions<void, Error, number>) {
   return useMutation({
     mutationFn: deleteObservation,
     ...options,
   });
-};
+}

--- a/hooks/queries/observations/useObservation.ts
+++ b/hooks/queries/observations/useObservation.ts
@@ -18,11 +18,12 @@ import {
   ObservationDetailResponse,
 } from '@/types/observation.type';
 
-export const useObservationRecentQuery = () => {
+export const useObservationRecentQuery = (enabled = true) => {
   return useQuery({
     queryKey: ['observations', 'recent'],
     queryFn: () => getObservations(),
     select: (data) => data.items.slice(0, 4),
+    enabled,
   });
 };
 

--- a/hooks/queries/user/useCredits.ts
+++ b/hooks/queries/user/useCredits.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { getCredits } from '@/api/credit.api';
 
-export const useCreditsQuery = () => {
+export function useCreditsQuery() {
   return useQuery({
     queryKey: ['credits'],
     queryFn: getCredits,
   });
-};
+}

--- a/hooks/queries/user/useCredits.ts
+++ b/hooks/queries/user/useCredits.ts
@@ -1,8 +1,8 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getCredits } from '@/api/credit.api';
 
 export const useCreditsQuery = () => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ['credits'],
     queryFn: getCredits,
   });

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+const QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+function subscribe(callback: () => void) {
+  const mediaQuery = window.matchMedia(QUERY);
+  mediaQuery.addEventListener('change', callback);
+  return () => mediaQuery.removeEventListener('change', callback);
+}
+
+function getSnapshot() {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - AI 관찰일지 페이지 모바일/태블릿 반응형 UI 대응

- ## 주요 변경(무엇을?):
  - 관찰일지 AI 생성 페이지 및 결과 페이지 반응형 UI 구현
  - ObservationCreditBadge 컴포넌트 분리
  - 모바일 환경 감지용 useIsMobile 훅 추가 및 SelectBottomSheet 적용

## 변경 내용

- [x] 관찰일지 AI 생성 페이지 반응형 UI 구현 (모바일/태블릿) 
- [x] 관찰일지 결과 페이지 반응형 UI 구현 (모바일/태블릿)
- [x] ObservationCreditBadge 공통 컴포넌트 분리 및 절대 위치 레이아웃 적용
- [x] 모바일 환경 감지용 useIsMobile 훅 추가
- [x] animate-lift 유틸 클래스 추가
  <img width="1339" height="640" alt="제목 없는 디자인" src="https://github.com/user-attachments/assets/53b791bd-ff47-4074-9033-6fbd33b950bf" />

### 세부 변경 사항

- 모바일에서 연령/5개 영역 선택 시 SelectBottomSheet로 대체
- 생성 로딩 중 생성 횟수 배지가 노출되지 않도록 ObservationLoading을 오버레이 구조로 변경
- useSuspenseQuery → useQuery 변경으로 SSR 환경 Invalid URL 에러 수정
- 비로그인 상태에서 최근 관찰일지 API 호출로 인해 로그인 모달이 노출되던 문제 수정

## 스크린샷/동영상 (선택)
- 관찰일지 AI 생성 페이지
  - 모바일
    <img width="357" height="739" alt="스크린샷 2026-05-17 오전 6 24 33" src="https://github.com/user-attachments/assets/56502c5b-e1f0-41ab-8aff-466896368531" />
  
  - 태블릿
    <img width="573" height="825" alt="스크린샷 2026-05-17 오전 6 22 24" src="https://github.com/user-attachments/assets/db7ed37e-8522-4930-8545-d8f9ec54040d" />

  - pc
    <img width="1916" height="923" alt="스크린샷 2026-05-17 오전 6 20 40" src="https://github.com/user-attachments/assets/18d3e559-1e10-4791-bc3a-cffc2b15f54a" />

  
- 관찰일지 결과 페이지
  - 모바일
    <img width="357" height="739" alt="스크린샷 2026-05-17 오전 6 23 50" src="https://github.com/user-attachments/assets/4802c564-a6a4-40cc-bb2e-ca7236be9c29" />

  - 태블릿
    <img width="573" height="825" alt="스크린샷 2026-05-17 오전 6 23 24" src="https://github.com/user-attachments/assets/8ad63924-7095-46ef-aa9f-3e41458679d0" />

  - pc
    <img width="1916" height="923" alt="스크린샷 2026-05-17 오전 6 21 00" src="https://github.com/user-attachments/assets/577c859f-ed24-4276-8fb5-4d462abb1f64" />

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #92


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized form controls with bottom-sheet selectors for age and area
  * Credit balance badge shown on the Observations page
  * New hover "lift" animation for result cards

* **Improvements**
  * Better loading and error fallbacks for observation forms and details
  * Improved layout and responsive styling across observation views
  * Recent observations now fetched conditionally based on auth state
  * Credits query no longer relies on suspense; added mobile detection hook

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->