### PR TITLE
Feature: 횟수 조회 API total 필드 추가에 따른 타입 및 UI 로직 수정

### DIFF
--- a/components/mypage/dashboard/DashboardSection.tsx
+++ b/components/mypage/dashboard/DashboardSection.tsx
@@ -19,8 +19,6 @@ export default function DashboardSection() {
   const { data: activitySummary } = useActivitySummaryQuery();
   const { data: credits } = useCreditsQuery();
 
-  const TOTAL_CREDITS = 10;
-
   const isMobile = useIsMobile();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
@@ -37,8 +35,8 @@ export default function DashboardSection() {
       />
 
       <GenerationCount
-        used={TOTAL_CREDITS - (credits?.balance ?? TOTAL_CREDITS)}
-        total={TOTAL_CREDITS}
+        balance={credits?.balance ?? 0}
+        total={credits?.total ?? 0}
         className="mt-7.5 xl:mt-22.5"
       />
 

--- a/components/mypage/dashboard/GenerationCount.tsx
+++ b/components/mypage/dashboard/GenerationCount.tsx
@@ -4,14 +4,14 @@ import { Tooltip } from '@/components/common/tooltip/Tooltip';
 import { cn } from '@/utils/cn';
 
 interface GenerationCountProps {
-  used: number;
+  balance: number;
   total: number;
   className?: string;
 }
 
-export function GenerationCount({ used, total, className }: GenerationCountProps) {
-  const remainingCount = total - used;
-  const progress = (used / total) * 100;
+export function GenerationCount({ balance, total, className }: GenerationCountProps) {
+  const remainingCount = balance;
+  const progress = total > 0 ? ((total - balance) / total) * 100 : 0;
 
   return (
     <section className={cn('flex flex-col gap-3 px-4 md:px-9 xl:px-0', className)}>

--- a/components/mypage/dashboard/GenerationCount.tsx
+++ b/components/mypage/dashboard/GenerationCount.tsx
@@ -11,7 +11,7 @@ interface GenerationCountProps {
 
 export function GenerationCount({ balance, total, className }: GenerationCountProps) {
   const remainingCount = balance;
-  const progress = total > 0 ? ((total - balance) / total) * 100 : 0;
+  const progress = total > 0 ? Math.min(100, Math.max(0, ((total - balance) / total) * 100)) : 0;
 
   return (
     <section className={cn('flex flex-col gap-3 px-4 md:px-9 xl:px-0', className)}>

--- a/types/credit.type.ts
+++ b/types/credit.type.ts
@@ -1,6 +1,7 @@
 export interface Credit {
   userId: number;
   balance: number;
+  total: number;
   dailyBonusChargedAmount: number;
   lastResetDate: string;
 }


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 횟수 조회 API 응답 스펙 변경(total 필드 추가)에 따른 타입 및 프로그레스바 로직 업데이트

- ## 주요 변경(무엇을?):
  - Credit 타입에 total 필드 추가
  - GenerationCount 컴포넌트 props 및 계산 로직 수정
  - DashboardSection에서 하드코딩 TOTAL_CREDITS 제거 및 API 값 사용

## 변경 내용

- [x] Credit 타입에 total: number 필드 추가
- [x] GenerationCount props used → balance/total로 변경 및 progress 계산 로직 수정
- [x] DashboardSection 하드코딩 TOTAL_CREDITS 제거, API 응답값 직접 사용

### 세부 변경 사항

- Credit 타입에 total: number 추가
- GenerationCount
  - props used → balance로 변경
  - progress 계산 로직 수정: ((total - balance) / total) * 100
- DashboardSection
  - TOTAL_CREDITS 상수 제거
  - credits.balance, credits.total 사용하도록 변경

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credit balance calculations to use actual data values instead of constant estimates, improving accuracy
  * Refined generation count display to correctly compute remaining resources based on current balance
  * Expanded credit metrics tracking to include total credits information for better visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->