### PR TITLE
Feature: 상세 페이지 북마크 수 API 연동 (#106)

### DIFF
--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -94,6 +94,7 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
           <BoardDetailSideActions
             postId={postId}
             likeCount={post.likeCount}
+            bookmarkCount={post.bookmarkCount}
             bookmarked={post.bookmarked}
             liked={post.isLiked}
           />

--- a/components/community/board/board-detail/BoardDetailSideActions.tsx
+++ b/components/community/board/board-detail/BoardDetailSideActions.tsx
@@ -7,6 +7,7 @@ import { useLikeMutation, useBookmarkMutation } from '@/hooks/queries/community/
 interface BoardDetailSideActionsProps {
   postId: number;
   likeCount: number;
+  bookmarkCount: number;
   bookmarked: boolean;
   liked: boolean;
 }
@@ -14,12 +15,14 @@ interface BoardDetailSideActionsProps {
 export default function BoardDetailSideActions({
   postId,
   likeCount,
+  bookmarkCount,
   bookmarked: initialBookmarked,
   liked: initialLiked,
 }: BoardDetailSideActionsProps) {
   const [isBookmarked, setIsBookmarked] = useState(initialBookmarked);
   const [isLiked, setIsLiked] = useState(initialLiked);
   const [optimisticLikeCount, setOptimisticLikeCount] = useState(likeCount);
+  const [optimisticBookmarkCount, setOptimisticBookmarkCount] = useState(bookmarkCount);
 
   const { mutate: toggleLike, isPending: isLikePending } = useLikeMutation(postId);
   const { mutate: toggleBookmark, isPending: isBookmarkPending } = useBookmarkMutation(postId);
@@ -41,10 +44,13 @@ export default function BoardDetailSideActions({
   function handleBookmarkToggle() {
     if (isBookmarkPending) return;
     const prevBookmarked = isBookmarked;
+    const prevCount = optimisticBookmarkCount;
     setIsBookmarked(!prevBookmarked);
+    setOptimisticBookmarkCount((prev) => (!prevBookmarked ? prev + 1 : prev - 1));
     toggleBookmark(prevBookmarked, {
       onError: () => {
         setIsBookmarked(prevBookmarked);
+        setOptimisticBookmarkCount(prevCount);
       },
     });
   }

--- a/components/community/board/board-detail/BoardDetailSideActions.tsx
+++ b/components/community/board/board-detail/BoardDetailSideActions.tsx
@@ -76,6 +76,9 @@ export default function BoardDetailSideActions({
               : '[&_path]:fill-transparent [&_path]:stroke-black-600'
           }
         />
+        <span aria-hidden="true" className="typo-line-p2 text-xs font-medium text-black-600">
+          {optimisticBookmarkCount}
+        </span>
       </button>
       <button
         type="button"

--- a/components/community/board/board-detail/board-detail.type.ts
+++ b/components/community/board/board-detail/board-detail.type.ts
@@ -26,6 +26,7 @@ export interface BoardDetail {
   viewCount: number;
   commentCount: number;
   likeCount: number;
+  bookmarkCount: number;
   bookmarked: boolean;
   isLiked: boolean;
   isMine: boolean;


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 디자인 가이드에 맞춰 API가 수정되어서 입니다.
- ## 주요 변경(무엇을?):
  - 북마크 수 추가
## 변경 내용

- [x] 북마크 수 추가

### 세부 변경 사항

- 게시글 상세 페이지 에서 bookmarkCount 수도 likeCount 처럼 표시

## 스크린샷/동영상 (선택)

<img width="951" height="681" alt="image" src="https://github.com/user-attachments/assets/c6f37a6a-4cf9-4250-9b57-e0ddb6c15a58" />


## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board posts now display the total number of bookmarks alongside like counts
  * Bookmark interactions provide optimistic updates, immediately reflecting user actions in the UI
  * Failed bookmark operations automatically restore the previous count and state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->