### PR TITLE
Feature: 댓글 프로필 이미지 적용 (#108)

### DIFF
--- a/components/community/board/board-detail/BoardDetailCommentItem.tsx
+++ b/components/community/board/board-detail/BoardDetailCommentItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import { MoreButton } from '@/components/common/more-button/MoreButton';
 import { Textarea } from '@/components/common/textarea/Textarea';
 import { Button } from '@/components/common/button/Button';
@@ -60,7 +61,19 @@ export default function BoardDetailCommentItem({
           },
         ]}
       />
-      <div aria-hidden="true" className="h-9 w-9 shrink-0 rounded-full bg-black-200" />
+      <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full bg-black-200">
+        {comment.profileImageUrl && (
+          <Image
+            src={comment.profileImageUrl}
+            alt={comment.authorNickname}
+            fill
+            className="object-cover"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        )}
+      </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center gap-1">

--- a/components/community/board/board-detail/board-detail.type.ts
+++ b/components/community/board/board-detail/board-detail.type.ts
@@ -36,6 +36,7 @@ export interface Comment {
   commentId: number;
   postId: number;
   authorNickname: string;
+  profileImageUrl: string | null;
   content: string;
   isMine: boolean;
   createdAt: string;


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - API에 profileImageUrl 추가되어서 적용
- ## 주요 변경(무엇을?):
  - 댓글 프로필 이미지 UI 변경
## 변경 내용

- [x] 프로필 이미지 추가

### 세부 변경 사항

- 상세 페이지 내에 댓글 기존 회색 동그라미에 -> 프로필 이미지로 수정

## 스크린샷/동영상 (선택)

<img width="1188" height="309" alt="스크린샷 2026-05-19 08 52 53" src="https://github.com/user-attachments/assets/075b31a0-2aa9-43a1-9d58-ffd2fd35d0dd" />

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #108
