### PR TITLE
Feature: 세션 자동 갱신 구현 (#87)

### DIFF
--- a/api/axios.ts
+++ b/api/axios.ts
@@ -44,12 +44,7 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const user = useUserStore.getState().user;
-    if (!user) {
-      useLoginModalStore.getState().open('로그인이 필요해요!', '로그인 후 이용할 수 있어요');
-      error.isHandled = true;
-      return Promise.reject(error);
-    }
+    const isLoggedIn = !!useUserStore.getState().user;
 
     if (isRefreshing) {
       return new Promise((resolve, reject) => {
@@ -70,7 +65,12 @@ apiClient.interceptors.response.use(
     } catch (refreshError) {
       processPendingQueue(refreshError);
       await fetch('/api/auth/logout', { method: 'POST' });
-      useLoginModalStore.getState().open('세션이 만료되었어요!', '다시 로그인해 주세요');
+      useLoginModalStore
+        .getState()
+        .open(
+          isLoggedIn ? '세션이 만료되었어요!' : '로그인이 필요해요!',
+          isLoggedIn ? '다시 로그인해 주세요' : '로그인 후 이용할 수 있어요',
+        );
       if (axios.isAxiosError(refreshError)) refreshError.isHandled = true;
       return Promise.reject(refreshError);
     } finally {


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 유저가 access token이 만료됐을 때, refresh 토큰으로 갱신하지 않고 로그인 모달이 나타나는 문제
- ## 주요 변경(무엇을?):
  - 기존 axios.ts 수정  

## 변경 내용

- [x] 갱신 기능 구현

### 세부 변경 사항

- user null 체크 및 즉시 로그인 모달 호출 블록 제거
- refresh 실패 시 isLoggedIn 기준으로 모달 메시지 분기
- api/axios.ts의 인터셉터에서 401 발생 시 무조건 refresh를 시도하도록 변경.

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login modal messaging to display context-appropriate messages based on session state. Users previously logged in now see a "session expired" message, while users who weren't logged in see a login prompt.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->