### PR TITLE
Fix: 모아쌤 QA 및 버그 수정 (#116)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
       <PainPointSection />
       <SolutionSection />
       <Footer />
-      <div className="fixed right-5 bottom-17.5 md:right-20">
+      <div className="fixed right-5 bottom-17.5 z-10 md:right-20">
         <ScrollToTopButton showAfter={300} />
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import PainPointSection from '@/components/home/PainPointSection';
 import SolutionSection from '@/components/home/SolutionSection';
 import Footer from '@/components/common/footer/Footer';
 import LoginRedirectHandler from '@/components/home/LoginRedirectHandler';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 
 export default function Home() {
   return (
@@ -17,6 +18,9 @@ export default function Home() {
       <PainPointSection />
       <SolutionSection />
       <Footer />
+      <div className="fixed right-5 bottom-17.5 md:right-20">
+        <ScrollToTopButton showAfter={300} />
+      </div>
     </div>
   );
 }

--- a/components/common/scroll-top/ScrollToTopButton.tsx
+++ b/components/common/scroll-top/ScrollToTopButton.tsx
@@ -17,6 +17,7 @@ export default function ScrollToTopButton({ showAfter }: ScrollToTopButtonProps)
     const el = scrollRef?.current;
     if (!el) return;
     const onScroll = () => setVisible(el.scrollTop > showAfter);
+    setVisible(el.scrollTop > showAfter);
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);
   }, [scrollRef, showAfter]);

--- a/components/common/scroll-top/ScrollToTopButton.tsx
+++ b/components/common/scroll-top/ScrollToTopButton.tsx
@@ -1,11 +1,31 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { TopIcon } from '@/app/assets/icons';
+import { useScrollRoot } from '@/lib/scroll-root';
 
-export default function ScrollToTopButton() {
+interface ScrollToTopButtonProps {
+  showAfter?: number;
+}
+
+export default function ScrollToTopButton({ showAfter }: ScrollToTopButtonProps) {
+  const scrollRef = useScrollRoot();
+  const [visible, setVisible] = useState(showAfter === undefined);
+
+  useEffect(() => {
+    if (showAfter === undefined) return;
+    const el = scrollRef?.current;
+    if (!el) return;
+    const onScroll = () => setVisible(el.scrollTop > showAfter);
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [scrollRef, showAfter]);
+
   const handleClick = () => {
-    document.querySelector('main')?.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollRef?.current?.scrollTo({ top: 0, behavior: 'smooth' });
   };
+
+  if (!visible) return null;
 
   return (
     <button

--- a/components/community/CommunityFab.tsx
+++ b/components/community/CommunityFab.tsx
@@ -4,15 +4,16 @@ import { PlusIcon } from '@/app/assets/icons';
 
 interface CommunityFabProps {
   onClick?: () => void;
+  className?: string;
 }
 
-export default function CommunityFab({ onClick }: CommunityFabProps) {
+export default function CommunityFab({ onClick, className }: CommunityFabProps) {
   return (
     <button
       type="button"
       aria-label="새글 작성"
       onClick={onClick}
-      className="fixed right-9 bottom-9 z-300 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-pink-500 shadow-lg transition-colors hover:bg-pink-600 xl:hidden"
+      className={`flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-pink-500 shadow-lg transition-colors hover:bg-pink-600 xl:hidden ${className ?? 'fixed right-9 bottom-9 z-300'}`}
     >
       <PlusIcon viewBox="1 1 14 14" className="h-4.5 w-4.5 text-white [&_path]:stroke-2" />
     </button>

--- a/components/community/CommunityFab.tsx
+++ b/components/community/CommunityFab.tsx
@@ -4,16 +4,16 @@ import { PlusIcon } from '@/app/assets/icons';
 
 interface CommunityFabProps {
   onClick?: () => void;
-  className?: string;
+  positionClassName?: string;
 }
 
-export default function CommunityFab({ onClick, className }: CommunityFabProps) {
+export default function CommunityFab({ onClick, positionClassName }: CommunityFabProps) {
   return (
     <button
       type="button"
       aria-label="새글 작성"
       onClick={onClick}
-      className={`flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-pink-500 shadow-lg transition-colors hover:bg-pink-600 xl:hidden ${className ?? 'fixed right-9 bottom-9 z-300'}`}
+      className={`flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-pink-500 shadow-lg transition-colors hover:bg-pink-600 xl:hidden ${positionClassName ?? 'fixed right-9 bottom-9 z-300'}`}
     >
       <PlusIcon viewBox="1 1 14 14" className="h-4.5 w-4.5 text-white [&_path]:stroke-2" />
     </button>

--- a/components/community/CommunityInfoTooltip.tsx
+++ b/components/community/CommunityInfoTooltip.tsx
@@ -12,8 +12,8 @@ export default function CommunityInfoTooltip({ className }: CommunityInfoTooltip
       <div className="rounded-lg bg-black-800 px-2.5 py-2 font-medium whitespace-nowrap">
         <p className="text-[11px] text-white">AI 생성횟수 추가 안내</p>
         <ul className="mt-1 space-y-0.5 text-[10px] text-black-100">
-          <li>・자유게시판 글 작성 시 1회</li>
           <li>・모아방 자료 업로드 시 3회</li>
+          <li>・자유게시판 글 작성 시 1회</li>
         </ul>
       </div>
     </div>

--- a/components/community/CommunitySearchOverlay.tsx
+++ b/components/community/CommunitySearchOverlay.tsx
@@ -76,7 +76,7 @@ export default function CommunitySearchOverlay({
         {showResults ? (
           <div style={{ opacity: isPending ? 0.5 : 1 }}>{renderResults(resultsKeyword)}</div>
         ) : (
-          <div className="flex h-full items-center justify-center text-sm text-black-500">
+          <div className="flex h-full items-center justify-center text-center text-sm text-black-500">
             궁금한 키워드를
             <br />
             입력해보세요

--- a/components/community/board/BoardSection.tsx
+++ b/components/community/board/BoardSection.tsx
@@ -19,6 +19,8 @@ import { useIsDesktop } from '@/hooks/useIsMobile';
 import { getValidParam } from '@/utils/getValidParam';
 import type { BoardPost, HeadTag } from './board.type';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import { useUserStore } from '@/stores/userStore';
+import { useLoginModalStore } from '@/stores/loginModalStore';
 
 function PostList({ posts }: { posts: BoardPost[] }) {
   return posts.length === 0 ? (
@@ -186,11 +188,21 @@ export default function BoardSection() {
   const searchParams = useSearchParams();
   const [, startTransition] = useTransition();
   const isDesktop = useIsDesktop();
+  const user = useUserStore((state) => state.user);
+  const openLoginModal = useLoginModalStore((state) => state.open);
 
   const keyword = searchParams.get('keyword') ?? '';
   const category = getValidParam(searchParams.get('category'), BOARD_CATEGORY_FILTER_TABS, 'all');
   const rawPage = Number(searchParams.get('page'));
   const currentPage = Number.isInteger(rawPage) && rawPage >= 1 ? rawPage : 1;
+
+  function handleWrite() {
+    if (!user) {
+      openLoginModal();
+      return;
+    }
+    router.push('/community/write?board=free');
+  }
 
   function updateParam(key: string, value: string, resetPage = false) {
     const params = new URLSearchParams(searchParams.toString());
@@ -218,11 +230,11 @@ export default function BoardSection() {
     <section className="flex flex-col" aria-label="게시글 목록">
       <CommunityTitleBar
         title="자유게시판"
-        onWrite={() => router.push('/community/write?board=free')}
+        onWrite={handleWrite}
         onSearch={handleSearch}
         renderSearchResults={(kw) => <BoardSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={() => router.push('/community/write?board=free')} />
+      <CommunityFab onClick={handleWrite} />
       {!keyword && (
         <CommunityFilter
           categoryTabs={BOARD_CATEGORY_FILTER_TABS}

--- a/components/community/board/BoardSection.tsx
+++ b/components/community/board/BoardSection.tsx
@@ -21,6 +21,7 @@ import type { BoardPost, HeadTag } from './board.type';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
 import { useUserStore } from '@/stores/userStore';
 import { useLoginModalStore } from '@/stores/loginModalStore';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 
 function PostList({ posts }: { posts: BoardPost[] }) {
   return posts.length === 0 ? (
@@ -234,7 +235,10 @@ export default function BoardSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <BoardSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} />
+      <CommunityFab onClick={handleWrite} className="fixed right-9 bottom-24 z-300" />
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
       {!keyword && (
         <CommunityFilter
           categoryTabs={BOARD_CATEGORY_FILTER_TABS}

--- a/components/community/board/BoardSection.tsx
+++ b/components/community/board/BoardSection.tsx
@@ -235,7 +235,7 @@ export default function BoardSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <BoardSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} className="fixed right-9 bottom-24 z-300" />
+      <CommunityFab onClick={handleWrite} positionClassName="fixed right-9 bottom-24 z-300" />
       <div className="fixed right-9 bottom-9 z-300 xl:hidden">
         <ScrollToTopButton showAfter={300} />
       </div>

--- a/components/community/board/board-detail/BoardDetailAttachments.tsx
+++ b/components/community/board/board-detail/BoardDetailAttachments.tsx
@@ -38,13 +38,9 @@ export default function BoardDetailAttachments({ files }: BoardDetailAttachments
           <span className="typo-line-p2 text-xs font-medium text-black-600">
             {formatFileSize(getTotalSize(files))}
           </span>
-          <button
-            type="button"
-            aria-label="전체 다운로드"
-            className="flex items-center text-black-600 hover:text-black-800"
-          >
+          <span aria-hidden="true" className="flex cursor-default items-center text-black-400">
             <DownloadIcon />
-          </button>
+          </span>
         </div>
       </div>
 

--- a/components/community/board/board-detail/BoardDetailCommentItem.tsx
+++ b/components/community/board/board-detail/BoardDetailCommentItem.tsx
@@ -7,14 +7,13 @@ import { Textarea } from '@/components/common/textarea/Textarea';
 import { Button } from '@/components/common/button/Button';
 import { Dialog } from '@/components/common/dialog/Dialog';
 import type { Comment } from './board-detail.type';
+import { formatDateTime } from '@/utils/formatDateTime';
 
 interface BoardDetailCommentItemProps {
   comment: Comment;
   onUpdate: (commentId: number, content: string) => void;
   onDelete: (commentId: number) => void;
 }
-
-import { formatDateTime } from '@/utils/formatDateTime';
 
 export default function BoardDetailCommentItem({
   comment,

--- a/components/community/board/board-detail/BoardDetailCommentItem.tsx
+++ b/components/community/board/board-detail/BoardDetailCommentItem.tsx
@@ -14,12 +14,7 @@ interface BoardDetailCommentItemProps {
   onDelete: (commentId: number) => void;
 }
 
-function formatCommentTime(isoString: string): string {
-  const date = new Date(isoString);
-  const hours = date.getHours().toString().padStart(2, '0');
-  const minutes = date.getMinutes().toString().padStart(2, '0');
-  return `${hours}:${minutes}`;
-}
+import { formatDateTime } from '@/utils/formatDateTime';
 
 export default function BoardDetailCommentItem({
   comment,
@@ -79,10 +74,10 @@ export default function BoardDetailCommentItem({
         <div className="flex items-center gap-1">
           <span className="text-sm font-semibold text-black-700">{comment.authorNickname}</span>
           <span
-            aria-label={`작성 시간 ${formatCommentTime(comment.createdAt)}`}
+            aria-label={`작성 시간 ${formatDateTime(comment.createdAt)}`}
             className="text-xs font-medium text-black-500"
           >
-            {formatCommentTime(comment.createdAt)}
+            {formatDateTime(comment.createdAt)}
           </span>
         </div>
 

--- a/components/community/board/board-detail/BoardDetailComments.tsx
+++ b/components/community/board/board-detail/BoardDetailComments.tsx
@@ -34,7 +34,10 @@ export default function BoardDetailComments({
   }
 
   return (
-    <section aria-label="댓글" className="rounded-2xl border border-black-200 bg-white p-7.5">
+    <section
+      aria-label="댓글"
+      className="rounded-2xl border border-black-200 bg-white p-4 xl:p-7.5"
+    >
       <h2 id="comments-title" className="typo-line-m2 text-base font-semibold text-black-800">
         댓글{' '}
         <span className={comments.length === 0 ? 'text-black-500' : 'text-pink-500'}>

--- a/components/community/board/board-detail/BoardDetailInlineActions.tsx
+++ b/components/community/board/board-detail/BoardDetailInlineActions.tsx
@@ -28,7 +28,22 @@ export default function BoardDetailInlineActions({
     if (isLikePending) return;
     const prev = isLiked;
     setIsLiked(!prev);
-    toggleLike(prev, { onError: () => setIsLiked(prev) });
+    toggleLike(prev, {
+      onSuccess: () => {
+        if (!prev) {
+          toast.success({
+            title: '좋아요를 눌렀어요',
+            description: '이 게시글에 좋아요를 표시했어요',
+          });
+        } else {
+          toast.success({
+            title: '좋아요를 취소했어요',
+            description: '언제든 다시 좋아요를 누를 수 있어요',
+          });
+        }
+      },
+      onError: () => setIsLiked(prev),
+    });
   }
 
   function handleBookmarkToggle() {

--- a/components/community/board/board-detail/BoardDetailInlineActions.tsx
+++ b/components/community/board/board-detail/BoardDetailInlineActions.tsx
@@ -42,6 +42,11 @@ export default function BoardDetailInlineActions({
             title: '북마크 저장 완료',
             description: '마이페이지 > 북마크에서 확인할 수 있어요',
           });
+        } else {
+          toast.success({
+            title: '북마크가 삭제되었어요',
+            description: '삭제해도 언제든 다시 북마크할 수 있어요',
+          });
         }
       },
       onError: () => setIsBookmarked(prev),

--- a/components/community/board/board-detail/BoardDetailPost.tsx
+++ b/components/community/board/board-detail/BoardDetailPost.tsx
@@ -7,7 +7,7 @@ import type { PostAge, ResourceType } from '@/components/community/moabang/moaba
 import BoardDetailAttachments from './BoardDetailAttachments';
 import BoardDetailInlineActions from './BoardDetailInlineActions';
 import type { BoardDetail } from './board-detail.type';
-import { formatRelativeTime } from '@/utils/formatRelativeTime';
+import { formatDateTime } from '@/utils/formatDateTime';
 
 const HEAD_TAG_LABELS: Record<string, string> = {
   QUESTION: '질문',
@@ -102,10 +102,10 @@ export default function BoardDetailPost({ post }: BoardDetailPostProps) {
               댓글 {post.commentCount}
             </span>
             <span
-              aria-label={`작성 시간 ${formatRelativeTime(post.createdAt)}`}
+              aria-label={`작성 시간 ${formatDateTime(post.createdAt)}`}
               className="text-xs font-medium text-black-500"
             >
-              {formatRelativeTime(post.createdAt)}
+              {formatDateTime(post.createdAt)}
             </span>
           </div>
           <BoardDetailInlineActions

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -60,6 +60,7 @@ function BoardDetailSideActionsLoader({ postId }: { postId: number }) {
   const { data: post } = usePostDetailQuery(postId);
   return (
     <BoardDetailSideActions
+      key={`${postId}-${post.bookmarked}-${post.isLiked}`}
       postId={postId}
       likeCount={post.likeCount}
       bookmarkCount={post.bookmarkCount}

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -60,7 +60,6 @@ function BoardDetailSideActionsLoader({ postId }: { postId: number }) {
   const { data: post } = usePostDetailQuery(postId);
   return (
     <BoardDetailSideActions
-      key={`${postId}-${post.bookmarked}`}
       postId={postId}
       likeCount={post.likeCount}
       bookmarkCount={post.bookmarkCount}

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/common/button/Button';
 import { Dialog } from '@/components/common/dialog/Dialog';
 import CommunityTitleBar from '@/components/community/CommunityTitleBar';
@@ -83,7 +84,15 @@ function BoardDetailContent({ postId, isLoggedIn }: { postId: number; isLoggedIn
 
 export default function BoardDetailSection({ postId, title }: BoardDetailSectionProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const user = useUserStore((state) => state.user);
+
+  useEffect(() => {
+    const listKey = title === '모아방' ? 'moabang' : 'board';
+    return () => {
+      queryClient.invalidateQueries({ queryKey: [listKey, 'posts'] });
+    };
+  }, [queryClient, title]);
   const isLoggedIn = user !== null;
   const { mutate: deletePost, isPending: isDeleting } = useDeletePostMutation();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -55,27 +55,29 @@ function BoardDetailHeaderActions({
   );
 }
 
+function BoardDetailSideActionsLoader({ postId }: { postId: number }) {
+  const { data: post } = usePostDetailQuery(postId);
+  return (
+    <BoardDetailSideActions
+      key={`${postId}-${post.bookmarked}`}
+      postId={postId}
+      likeCount={post.likeCount}
+      bookmarkCount={post.bookmarkCount}
+      bookmarked={post.bookmarked}
+      liked={post.isLiked}
+    />
+  );
+}
+
 function BoardDetailContent({ postId, isLoggedIn }: { postId: number; isLoggedIn: boolean }) {
   const { data: post } = usePostDetailQuery(postId);
   return (
-    <div className="flex items-start gap-4">
-      <div className="min-w-0 flex-1">
-        <BoardDetailPost post={post} />
-        <div className="mt-7.5">
-          <BoardDetailComments postId={postId} comments={post.comments} isLoggedIn={isLoggedIn} />
-        </div>
+    <>
+      <BoardDetailPost post={post} />
+      <div className="mt-7.5">
+        <BoardDetailComments postId={postId} comments={post.comments} isLoggedIn={isLoggedIn} />
       </div>
-      <div className="sticky top-[263.2px] hidden shrink-0 xl:block">
-        <BoardDetailSideActions
-          key={`${postId}-${post.bookmarked}`}
-          postId={postId}
-          likeCount={post.likeCount}
-          bookmarkCount={post.bookmarkCount}
-          bookmarked={post.bookmarked}
-          liked={post.isLiked}
-        />
-      </div>
-    </div>
+    </>
   );
 }
 
@@ -115,33 +117,42 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
           { children: '삭제', variant: 'primary', onClick: confirmDelete, disabled: isDeleting },
         ]}
       />
-      <CommunityTitleBar
-        title={title}
-        showBackButton
-        actions={
-          <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
-            <BoardDetailHeaderActions
-              postId={postId}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              isDeleting={isDeleting}
-            />
-          </AsyncBoundary>
-        }
-      />
-      <AsyncBoundary
-        pendingFallback={<LoadingSpinner className="mt-[20vh]" />}
-        rejectedFallback={({ error, reset }) => (
-          <ErrorFallback
-            error={error}
-            actionLabel="다시 시도"
-            onAction={reset}
-            className="pt-7.5"
+      <div className="flex items-start gap-4">
+        <div className="min-w-0 flex-1">
+          <CommunityTitleBar
+            title={title}
+            showBackButton
+            actions={
+              <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
+                <BoardDetailHeaderActions
+                  postId={postId}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  isDeleting={isDeleting}
+                />
+              </AsyncBoundary>
+            }
           />
-        )}
-      >
-        <BoardDetailContent postId={postId} isLoggedIn={isLoggedIn} />
-      </AsyncBoundary>
+          <AsyncBoundary
+            pendingFallback={<LoadingSpinner className="mt-[20vh]" />}
+            rejectedFallback={({ error, reset }) => (
+              <ErrorFallback
+                error={error}
+                actionLabel="다시 시도"
+                onAction={reset}
+                className="pt-7.5"
+              />
+            )}
+          >
+            <BoardDetailContent postId={postId} isLoggedIn={isLoggedIn} />
+          </AsyncBoundary>
+        </div>
+        <div className="sticky top-[263.2px] hidden shrink-0 xl:block">
+          <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
+            <BoardDetailSideActionsLoader postId={postId} />
+          </AsyncBoundary>
+        </div>
+      </div>
       <div className="fixed right-20 bottom-17.5 hidden xl:block">
         <ScrollToTopButton />
       </div>

--- a/components/community/board/board-detail/BoardDetailSideActions.tsx
+++ b/components/community/board/board-detail/BoardDetailSideActions.tsx
@@ -55,6 +55,11 @@ export default function BoardDetailSideActions({
             title: '북마크 저장 완료',
             description: '마이페이지 > 북마크에서 확인할 수 있어요',
           });
+        } else {
+          toast.success({
+            title: '북마크가 삭제되었어요',
+            description: '삭제해도 언제든 다시 북마크할 수 있어요',
+          });
         }
       },
       onError: () => {

--- a/components/community/board/board-detail/BoardDetailSideActions.tsx
+++ b/components/community/board/board-detail/BoardDetailSideActions.tsx
@@ -35,6 +35,19 @@ export default function BoardDetailSideActions({
     setIsLiked(!prevLiked);
     setOptimisticLikeCount((prev) => (!prevLiked ? prev + 1 : prev - 1));
     toggleLike(prevLiked, {
+      onSuccess: () => {
+        if (!prevLiked) {
+          toast.success({
+            title: '좋아요를 눌렀어요',
+            description: '이 게시글에 좋아요를 표시했어요',
+          });
+        } else {
+          toast.success({
+            title: '좋아요를 취소했어요',
+            description: '언제든 다시 좋아요를 누를 수 있어요',
+          });
+        }
+      },
       onError: () => {
         setIsLiked(prevLiked);
         setOptimisticLikeCount(prevCount);

--- a/components/community/edit/EditBoundary.tsx
+++ b/components/community/edit/EditBoundary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import CommunityTitleBar from '@/components/community/CommunityTitleBar';
 import EditSection from './EditSection';
 
 interface EditBoundaryProps {
@@ -10,7 +11,12 @@ interface EditBoundaryProps {
 export default function EditBoundary({ postId }: EditBoundaryProps) {
   return (
     <AsyncBoundary
-      pendingFallback={<LoadingSpinner className="mt-[20vh]" />}
+      pendingFallback={
+        <>
+          <CommunityTitleBar title="게시글 수정" hideSearch />
+          <LoadingSpinner className="mt-[20vh]" />
+        </>
+      }
       rejectedFallback={({ error, reset }) => (
         <ErrorFallback error={error} actionLabel="다시 시도" onAction={reset} className="pt-7.5" />
       )}

--- a/components/community/moabang/MoabangSection.tsx
+++ b/components/community/moabang/MoabangSection.tsx
@@ -24,6 +24,7 @@ import type { PostAge, ResourceType, MoabangPost } from './moabang.type';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
 import { useUserStore } from '@/stores/userStore';
 import { useLoginModalStore } from '@/stores/loginModalStore';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 
 function PostGrid({ posts }: { posts: MoabangPost[] }) {
   return posts.length === 0 ? (
@@ -242,7 +243,10 @@ export default function MoabangSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <MoabangSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} />
+      <CommunityFab onClick={handleWrite} className="fixed right-9 bottom-24 z-300" />
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
       {!keyword && (
         <CommunityFilter
           ageTabs={MOABANG_AGE_FILTER_TABS}

--- a/components/community/moabang/MoabangSection.tsx
+++ b/components/community/moabang/MoabangSection.tsx
@@ -22,6 +22,8 @@ import { useIsDesktop } from '@/hooks/useIsMobile';
 import { getValidParam } from '@/utils/getValidParam';
 import type { PostAge, ResourceType, MoabangPost } from './moabang.type';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import { useUserStore } from '@/stores/userStore';
+import { useLoginModalStore } from '@/stores/loginModalStore';
 
 function PostGrid({ posts }: { posts: MoabangPost[] }) {
   return posts.length === 0 ? (
@@ -193,6 +195,8 @@ export default function MoabangSection() {
   const searchParams = useSearchParams();
   const [, startTransition] = useTransition();
   const isDesktop = useIsDesktop();
+  const user = useUserStore((state) => state.user);
+  const openLoginModal = useLoginModalStore((state) => state.open);
 
   const keyword = searchParams.get('keyword') ?? '';
   const age = getValidParam(searchParams.get('age'), MOABANG_AGE_FILTER_TABS, 'all');
@@ -222,15 +226,23 @@ export default function MoabangSection() {
     updateParam('page', String(page));
   }
 
+  function handleWrite() {
+    if (!user) {
+      openLoginModal();
+      return;
+    }
+    router.push('/community/write?board=moabang');
+  }
+
   return (
     <section className="flex flex-col" aria-label="게시글 목록">
       <CommunityTitleBar
         title="모아방"
-        onWrite={() => router.push('/community/write?board=moabang')}
+        onWrite={handleWrite}
         onSearch={handleSearch}
         renderSearchResults={(kw) => <MoabangSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={() => router.push('/community/write?board=moabang')} />
+      <CommunityFab onClick={handleWrite} />
       {!keyword && (
         <CommunityFilter
           ageTabs={MOABANG_AGE_FILTER_TABS}

--- a/components/community/moabang/MoabangSection.tsx
+++ b/components/community/moabang/MoabangSection.tsx
@@ -243,7 +243,7 @@ export default function MoabangSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <MoabangSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} className="fixed right-9 bottom-24 z-300" />
+      <CommunityFab onClick={handleWrite} positionClassName="fixed right-9 bottom-24 z-300" />
       <div className="fixed right-9 bottom-9 z-300 xl:hidden">
         <ScrollToTopButton showAfter={300} />
       </div>

--- a/components/community/write/WriteEditor.tsx
+++ b/components/community/write/WriteEditor.tsx
@@ -109,7 +109,7 @@ export default function WriteEditor({
   const [showFontSizeSheet, setShowFontSizeSheet] = useState(false);
   const [pickerPos, setPickerPos] = useState({ top: 0, left: 0 });
   const [activeColor, setActiveColor] = useState('#343434');
-  const [activeHighlightColor, setActiveHighlightColor] = useState('#FCB900');
+  const [activeHighlightColor, setActiveHighlightColor] = useState('#343434');
   const isMobile = useIsMobile();
 
   const openPicker = useCallback(
@@ -119,14 +119,16 @@ export default function WriteEditor({
       initialColor?: string,
       colorSetter?: React.Dispatch<React.SetStateAction<string>>,
     ) => {
-      const rect = ref.current?.getBoundingClientRect();
-      if (rect) setPickerPos({ top: rect.bottom + 4, left: rect.left });
+      if (!isMobile) {
+        const rect = ref.current?.getBoundingClientRect();
+        if (rect) setPickerPos({ top: rect.bottom + 4, left: rect.left });
+      }
       setter((v) => {
         if (!v && initialColor !== undefined) colorSetter?.(initialColor);
         return !v;
       });
     },
-    [],
+    [isMobile],
   );
 
   async function handleImageUpload(e: React.ChangeEvent<HTMLInputElement>) {
@@ -237,7 +239,7 @@ export default function WriteEditor({
       fontFamily: ctx.editor?.getAttributes('textStyle').fontFamily ?? 'Pretendard',
       fontSize: ctx.editor?.getAttributes('textStyle').fontSize?.replace('px', '') ?? '16',
       color: ctx.editor?.getAttributes('textStyle').color ?? '#343434',
-      highlightColor: ctx.editor?.getAttributes('highlight').color ?? '#343434',
+      highlightColor: ctx.editor?.getAttributes('highlight').color ?? '#FCB900',
     }),
   });
 
@@ -246,7 +248,7 @@ export default function WriteEditor({
   const currentFontFamily = editorState?.fontFamily ?? 'Pretendard';
   const currentFontSize = editorState?.fontSize ?? '16';
   const currentColor = editorState?.color ?? '#343434';
-  const currentHighlightColor = editorState?.highlightColor ?? '#FCB900';
+  const currentHighlightColor = editorState?.highlightColor ?? '#343434';
 
   return (
     <div
@@ -348,9 +350,10 @@ export default function WriteEditor({
 
         <div ref={colorBtnRef}>
           <ToolbarButton
-            onClick={() =>
-              openPicker(colorBtnRef, setShowColorPicker, currentColor, setActiveColor)
-            }
+            onClick={() => {
+              if (isMobile) setShowHighlightPicker(false);
+              openPicker(colorBtnRef, setShowColorPicker, currentColor, setActiveColor);
+            }}
             title="글자색"
           >
             <EditorTextColorIcon style={{ color: currentColor }} />
@@ -359,14 +362,15 @@ export default function WriteEditor({
 
         <div ref={highlightBtnRef}>
           <ToolbarButton
-            onClick={() =>
+            onClick={() => {
+              if (isMobile) setShowColorPicker(false);
               openPicker(
                 highlightBtnRef,
                 setShowHighlightPicker,
                 currentHighlightColor,
                 setActiveHighlightColor,
-              )
-            }
+              );
+            }}
             title="형광펜"
           >
             <EditorTextfillIcon style={{ color: currentHighlightColor }} />
@@ -490,6 +494,24 @@ export default function WriteEditor({
         </div>
       </BubbleMenu>
 
+      {isMobile && (showColorPicker || showHighlightPicker) && (
+        <MobileColorPalette
+          colors={PICKER_COLORS}
+          activeColor={showColorPicker ? activeColor : activeHighlightColor}
+          onSelect={(color) => {
+            if (showColorPicker) {
+              setActiveColor(color);
+              editor.chain().setColor(color).run();
+              setShowColorPicker(false);
+            } else {
+              setActiveHighlightColor(color);
+              editor.chain().setHighlight({ color }).run();
+              setShowHighlightPicker(false);
+            }
+          }}
+        />
+      )}
+
       {isMobile && (files.length > 0 || existingFiles.length > 0) && (
         <div className="grid grid-cols-2 gap-2 p-3">
           {existingFiles.map((file) => (
@@ -587,7 +609,7 @@ export default function WriteEditor({
         </>
       )}
 
-      {showColorPicker && (
+      {!isMobile && showColorPicker && (
         <>
           <div className="fixed inset-0 z-900" onClick={() => setShowColorPicker(false)} />
           <div className="fixed z-1100" style={{ top: pickerPos.top, left: pickerPos.left }}>
@@ -603,7 +625,7 @@ export default function WriteEditor({
         </>
       )}
 
-      {showHighlightPicker && (
+      {!isMobile && showHighlightPicker && (
         <>
           <div className="fixed inset-0 z-900" onClick={() => setShowHighlightPicker(false)} />
           <div className="fixed z-1100" style={{ top: pickerPos.top, left: pickerPos.left }}>
@@ -618,6 +640,75 @@ export default function WriteEditor({
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+function MobileColorPalette({
+  colors,
+  activeColor,
+  onSelect,
+}: {
+  colors: string[];
+  activeColor: string;
+  onSelect: (color: string) => void;
+}) {
+  const [hexInput, setHexInput] = useState(activeColor.replace('#', ''));
+
+  function handleHexChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setHexInput(e.target.value);
+  }
+
+  const isValidHex = /^[0-9a-fA-F]{6}$/.test(hexInput);
+  const previewColor = isValidHex ? `#${hexInput}` : activeColor;
+
+  return (
+    <div className="flex flex-col gap-2 border-b border-black-200 bg-black-100 px-3 py-2">
+      <div className="flex items-center gap-1.5">
+        {colors.map((color) => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => onSelect(color)}
+            className="h-6 w-6 shrink-0 rounded-full border-2 border-white shadow-sm transition-transform active:scale-90"
+            style={{ backgroundColor: color }}
+          />
+        ))}
+      </div>
+      <div className="flex items-center justify-center gap-1">
+        <div
+          className="h-6 w-6 shrink-0 rounded border border-black-200 shadow-sm"
+          style={{ backgroundColor: previewColor }}
+        />
+        <div className="flex h-6 items-center rounded border border-black-200 bg-white px-1.5 focus-within:border-black-400">
+          <span className={`text-xs ${hexInput.length > 0 ? 'text-black-800' : 'text-black-300'}`}>
+            #
+          </span>
+          <input
+            type="text"
+            inputMode="text"
+            value={hexInput}
+            onChange={handleHexChange}
+            onKeyDown={(e) => e.stopPropagation()}
+            maxLength={6}
+            onBlur={() => {
+              if (!isValidHex) setHexInput(activeColor.replace('#', ''));
+            }}
+            placeholder="000000"
+            className="w-14 bg-transparent text-xs text-black-800 outline-none placeholder:text-black-300"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            if (isValidHex) onSelect(`#${hexInput}`);
+          }}
+          disabled={!isValidHex}
+          className="h-6 rounded border border-black-200 px-2 text-xs text-black-700 transition-colors hover:bg-black-200 disabled:opacity-40"
+        >
+          확인
+        </button>
+      </div>
     </div>
   );
 }

--- a/components/community/write/WriteForm.tsx
+++ b/components/community/write/WriteForm.tsx
@@ -131,7 +131,7 @@ export default function WriteForm({
         { request, files: values.files },
         {
           onSuccess: ({ postId: updatedPostId }) => {
-            router.push(`/community/${path}/${updatedPostId}`);
+            router.replace(`/community/${path}/${updatedPostId}`);
           },
           onError: () => {
             toast.error({ title: '게시글 수정 실패', description: '잠시 후 다시 시도해주세요' });
@@ -152,7 +152,7 @@ export default function WriteForm({
         { request, files: values.files },
         {
           onSuccess: ({ postId: createdPostId }) => {
-            router.push(`/community/${path}/${createdPostId}`);
+            router.replace(`/community/${path}/${createdPostId}`);
           },
           onError: () => {
             toast.error({ title: '게시글 등록 실패', description: '잠시 후 다시 시도해주세요' });

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -8,6 +8,7 @@ import HeroImage from '@/app/assets/images/home/hero/hero-section.png';
 import HeroImageMd from '@/app/assets/images/home/hero/hero-section-md.png';
 import { useUser } from '@/lib/user-context';
 import { useCreditsQuery } from '@/hooks/queries/user/useCredits';
+import { ChevronRightIcon } from '@/app/assets/icons';
 import { AsyncBoundary } from '@/lib/async-boundary';
 import { ObservationCreditBadge } from '@/components/common/observation-credit-badge/ObservationCreditBadge';
 
@@ -60,7 +61,8 @@ function LoggedInHero({ userName = '' }: { userName: string }) {
             href="/observations"
             className="flex h-8 w-30 cursor-pointer items-center justify-center rounded-lg bg-pink-500 text-xs font-medium text-white transition-colors hover:bg-pink-600 md:h-13 md:w-57.5 md:text-xl"
           >
-            관찰일지 시작하기 &gt;
+            관찰일지 시작하기{' '}
+            <ChevronRightIcon className="ml-1 h-2 w-1 overflow-visible md:ml-2.5 md:h-5 md:w-1.5" />
           </Link>
         </div>
       </motion.div>

--- a/components/home/ServiceCard.tsx
+++ b/components/home/ServiceCard.tsx
@@ -30,14 +30,14 @@ export default function ServiceCard({
         alt=""
         width={150}
         height={141}
-        className="absolute top-0 right-3.75 z-5 h-23.5 w-25 transition-opacity group-hover:opacity-0 md:right-0 md:h-auto md:w-auto"
+        className="absolute top-0 right-3.75 z-5 transition-opacity group-hover:opacity-0 max-md:h-23.5 max-md:w-25 md:right-0"
       />
       <Image
         src={characterHoverSrc}
         alt=""
         width={130}
         height={145}
-        className="absolute top-0 right-3.75 z-5 h-23.5 w-25 opacity-0 transition-opacity group-hover:z-10 group-hover:opacity-100 md:right-2 md:h-auto md:w-auto"
+        className="absolute top-0 right-3.75 z-5 opacity-0 transition-opacity group-hover:z-10 group-hover:opacity-100 max-md:h-23.5 max-md:w-25 md:right-2"
       />
 
       <div className="relative flex h-28.25 w-full flex-col md:h-49.75">

--- a/constants/community/community-tabs.ts
+++ b/constants/community/community-tabs.ts
@@ -3,6 +3,7 @@ import type { TabOption } from '@/components/common/tabs/Tabs';
 const ALL_TAB: TabOption = { label: '전체', value: 'all' };
 
 export const MOABANG_AGES: TabOption[] = [
+  { label: '전체 연령', value: 'ALL' },
   { label: '영아', value: 'INFANT' },
   { label: '만 3세', value: 'AGE_3' },
   { label: '만 4세', value: 'AGE_4' },

--- a/utils/formatDateTime.ts
+++ b/utils/formatDateTime.ts
@@ -1,0 +1,10 @@
+export function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return '';
+  const yyyy = date.getFullYear();
+  const mm = (date.getMonth() + 1).toString().padStart(2, '0');
+  const dd = date.getDate().toString().padStart(2, '0');
+  const hh = date.getHours().toString().padStart(2, '0');
+  const min = date.getMinutes().toString().padStart(2, '0');
+  return `${yyyy}.${mm}.${dd}. ${hh}:${min}`;
+}


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 피드백 기반 UI/UX 버그 수정
- ## 주요 변경(무엇을?)
  - 버그 수정

## 변경 내용
  
- [x] qa 변경사항 적용

### 세부 변경 사항

- 모바일 에디터 컬러피커 인라인 팔레트로 교체
- BoardDetailSection 수정/삭제 버튼 콘텐츠 컬럼 정렬 수정
- 모아방 연령 선택에 '전체 연령' 옵션 추가
- 수정 페이지 로딩 스피너 위치 수정
- 모아방, 자유게시판 목록 및 홈에 스크롤 탑 버튼 추가
- FAB 로그인/비로그인 분기 처리
- 홈 서비스 카드 캐릭터 이미지 위치 정상화
- 상세 페이지 게시글·댓글 날짜 형식 yyyy.MM.dd. HH:mm 으로 변경

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scroll-to-top button added to pages and mobile views for easier navigation
  * Mobile-optimized color picker UI for rich text formatting

* **Bug Fixes**
  * Download control rendered as non-interactive display for attachments

* **UI/UX Improvements**
  * Clearer success notifications for like/bookmark actions
  * Timestamps switched to absolute date/time for posts and comments
  * Login modal now appears for non-authenticated users trying to write
  * Minor visual and responsive spacing refinements (icons, overlays, FAB positioning)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->