### PR TITLE
Fix: 모아쌤 QA 및 버그 수정 (#120)

### DIFF
--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -5,5 +5,5 @@ export default async function MyPageLayout({ children }: { children: React.React
   const user = await getProfile();
   if (!user) redirect('/?login=required');
 
-  return <div className="xl:px-20 xl:py-20">{children}</div>;
+  return <div className="xl:px-20 xl:py-15">{children}</div>;
 }

--- a/app/observations/layout.tsx
+++ b/app/observations/layout.tsx
@@ -9,7 +9,7 @@ export default function ObservationsLayout({ children }: { children: React.React
         <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-5 md:right-8 md:left-auto md:translate-x-0 xl:top-6 xl:right-20">
           <ObservationCreditBadgeWrapper />
         </div>
-        <div className="px-4 py-16 md:px-9 md:py-18 xl:px-20 xl:pt-25 xl:pb-15">{children}</div>
+        <div className="p-4 md:p-9 xl:p-20">{children}</div>
       </div>
     </div>
   );

--- a/components/common/bottom-sheet/BottomSheet.tsx
+++ b/components/common/bottom-sheet/BottomSheet.tsx
@@ -24,6 +24,7 @@ export function BottomSheet({
             'flex flex-col rounded-t-[20px] bg-white',
             'focus:outline-none',
           )}
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div
             className={cn(

--- a/components/common/header/Header.tsx
+++ b/components/common/header/Header.tsx
@@ -13,6 +13,7 @@ import NAV_ITEMS from '@/constants/common/nav-items';
 import { useLogoutMutation } from '@/hooks/queries/auth/useAuth';
 import { useUser } from '@/lib/user-context';
 import NavMenu from '@/components/common/nav-menu/NavMenu';
+import { toast } from '@/utils/toast';
 
 export default function Header() {
   const openLoginModal = useLoginModalStore((state) => state.open);
@@ -43,6 +44,9 @@ export default function Header() {
       setIsPopoverOpen(false);
       router.push('/');
       router.refresh();
+    },
+    onError: () => {
+      toast.error({ title: '로그아웃에 실패했어요. 다시 시도해주세요.' });
     },
   });
 

--- a/components/common/header/Header.tsx
+++ b/components/common/header/Header.tsx
@@ -42,6 +42,7 @@ export default function Header() {
   const { mutate: handleLogout } = useLogoutMutation({
     onSuccess: () => {
       setIsPopoverOpen(false);
+      toast.success({ title: '로그아웃 완료', description: '안전하게 로그아웃되었어요.' });
       router.push('/');
       router.refresh();
     },

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -242,7 +242,13 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                 <ChevronDownIcon className="h-4 w-4 shrink-0 -rotate-90 text-black" />
               </Link>
               <div className="flex justify-end bg-black-100 py-4 pr-4 md:pr-9">
-                <button onClick={onLogout} className="text-xs text-black-500">
+                <button
+                  onClick={() => {
+                    onClose();
+                    onLogout();
+                  }}
+                  className="text-xs text-black-500"
+                >
                   로그아웃
                 </button>
               </div>

--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -173,6 +173,18 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                           className="mt-2 flex items-center gap-2 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           최근 관찰일지
+                          {recentObservations && (
+                            <span
+                              className={cn(
+                                'text-xs font-semibold',
+                                recentObservations.length === 0
+                                  ? 'text-black-500'
+                                  : 'text-pink-500',
+                              )}
+                            >
+                              {recentObservations.length}
+                            </span>
+                          )}
                           <ChevronDownIcon className="h-3 w-3 -rotate-90 text-black" />
                         </Link>
                         {recentObservations && recentObservations.length > 0 && (

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -63,7 +63,7 @@ export function Select(props: SelectProps) {
       props.onChange?.(next);
     } else {
       props.onChange?.(optionValue);
-      if (size === 'sm') setIsOpen(false);
+      setIsOpen(false);
     }
   }
 

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -22,7 +22,14 @@ const ICON_SIZE: Record<SelectSize, number> = {
 };
 
 export function Select(props: SelectProps) {
-  const { size = 'sm', options, triggerLabel = '', className, fixedMenu = false } = props;
+  const {
+    size = 'sm',
+    options,
+    triggerLabel = '',
+    triggerDescription,
+    className,
+    fixedMenu = false,
+  } = props;
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [menuStyle, setMenuStyle] = useState<{ top: number; left: number; width: number }>({
@@ -84,7 +91,12 @@ export function Select(props: SelectProps) {
           isOpen && size === 'md' && 'rounded-b-none',
         )}
       >
-        <span>{getTriggerLabel()}</span>
+        <span className="flex items-center gap-1">
+          {getTriggerLabel()}
+          {triggerDescription && (
+            <span className="text-xs font-medium text-black-500">{triggerDescription}</span>
+          )}
+        </span>
         <ChevronDownIcon
           width={iconSize}
           height={iconSize}

--- a/components/common/select/select.type.ts
+++ b/components/common/select/select.type.ts
@@ -9,6 +9,7 @@ interface SelectSharedProps {
   size?: SelectSize;
   options: SelectOption[];
   triggerLabel?: string;
+  triggerDescription?: string;
   className?: string;
   fixedMenu?: boolean;
 }

--- a/components/mypage/bookmarks/BookmarksBoundary.tsx
+++ b/components/mypage/bookmarks/BookmarksBoundary.tsx
@@ -10,7 +10,7 @@ export default function BookmarksBoundary() {
 
   return (
     <div className="flex flex-col gap-2 xl:gap-3">
-      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
+      <div className="flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>

--- a/components/mypage/bookmarks/BookmarksBoundary.tsx
+++ b/components/mypage/bookmarks/BookmarksBoundary.tsx
@@ -9,14 +9,14 @@ export default function BookmarksBoundary() {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="flex items-center gap-4 bg-white px-4 py-3 md:px-9 xl:hidden">
+    <div className="flex flex-col gap-2 xl:gap-3">
+      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>
-        <h1 className="text-base font-semibold text-black md:text-[18px]">북마크</h1>
+        <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">북마크</h1>
       </div>
-      <h1 className="hidden text-lg font-semibold text-black xl:block">북마크</h1>
+      <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">북마크</h1>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/comments/CommentsBoundary.tsx
+++ b/components/mypage/comments/CommentsBoundary.tsx
@@ -10,7 +10,7 @@ export default function CommentsBoundary() {
 
   return (
     <div className="flex flex-col gap-2 xl:gap-3">
-      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
+      <div className="flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>

--- a/components/mypage/comments/CommentsBoundary.tsx
+++ b/components/mypage/comments/CommentsBoundary.tsx
@@ -9,14 +9,14 @@ export default function CommentsBoundary() {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="flex items-center gap-4 bg-white px-4 py-3 md:px-9 xl:hidden">
+    <div className="flex flex-col gap-2 xl:gap-3">
+      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>
-        <h1 className="text-base font-semibold text-black md:text-[18px]">댓글</h1>
+        <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">댓글</h1>
       </div>
-      <h1 className="hidden text-lg font-semibold text-black xl:block">댓글</h1>
+      <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">댓글</h1>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/comments/CommentsSection.tsx
+++ b/components/mypage/comments/CommentsSection.tsx
@@ -12,20 +12,30 @@ function formatDate(dateStr: string) {
   return dateStr.slice(0, 10).replace(/-/g, '.');
 }
 
+const CATEGORY_LABEL: Record<string, string> = {
+  MOABANG: '모아방',
+  FREE: '자유게시판',
+};
+
 function CommentItem({ comment }: { comment: MyComment }) {
   return (
-    <Link
-      href={`/community/${comment.category === 'MOABANG' ? 'moabang' : 'board'}/${comment.postId}`}
-      className="animate-lift flex min-w-0 flex-1 flex-col gap-1 rounded-[10px] bg-white px-5 py-3 md:flex-row md:items-center"
-    >
-      <span className="min-w-0 flex-1 truncate text-sm font-medium text-black-800">
-        {comment.content}
-      </span>
-      <div className="flex items-center gap-5 text-xs font-medium text-black-500 md:pl-10">
-        <span className="w-40 truncate md:w-auto">{comment.postTitle}</span>
-        <span>{formatDate(comment.createdAt)}</span>
-      </div>
-    </Link>
+    <div className="animate-lift flex items-center rounded-[10px] bg-white px-5 py-3">
+      <Link
+        href={`/community/${comment.category === 'MOABANG' ? 'moabang' : 'board'}/${comment.postId}`}
+        className="flex min-w-0 flex-1 flex-col gap-1 md:flex-row md:items-center"
+      >
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-black-800">
+          {comment.content}
+        </span>
+        <div className="flex items-center gap-5 text-xs font-medium text-black-500 md:pl-10">
+          <span className="w-14 shrink-0 md:w-auto">
+            {CATEGORY_LABEL[comment.category] ?? comment.category}
+          </span>
+          <span className="w-21.75 truncate">{comment.postTitle}</span>
+          <span className="shrink-0">{formatDate(comment.createdAt)}</span>
+        </div>
+      </Link>
+    </div>
   );
 }
 

--- a/components/mypage/dashboard/DashboardSection.tsx
+++ b/components/mypage/dashboard/DashboardSection.tsx
@@ -55,6 +55,7 @@ export default function DashboardSection() {
           }}
           username={user?.email ?? ''}
           nickname={user?.nickname ?? ''}
+          profileImageUrl={user?.profileImageUrl}
         />
       ) : (
         <ProfileEditModal
@@ -67,6 +68,7 @@ export default function DashboardSection() {
           }}
           username={user?.email ?? ''}
           nickname={user?.nickname ?? ''}
+          profileImageUrl={user?.profileImageUrl}
         />
       )}
       {isMobile ? (

--- a/components/mypage/dashboard/ProfileEditBottomSheet.tsx
+++ b/components/mypage/dashboard/ProfileEditBottomSheet.tsx
@@ -15,6 +15,7 @@ interface ProfileEditBottomSheetProps {
   onWithdrawClick: () => void;
   username: string;
   nickname: string;
+  profileImageUrl?: string | null;
 }
 
 export function ProfileEditBottomSheet({
@@ -23,6 +24,7 @@ export function ProfileEditBottomSheet({
   onWithdrawClick,
   username,
   nickname,
+  profileImageUrl,
 }: ProfileEditBottomSheetProps) {
   const [displayName, setDisplayName] = useState(nickname);
   const router = useRouter();
@@ -47,7 +49,12 @@ export function ProfileEditBottomSheet({
     >
       <div className="flex h-102 flex-col px-4 pb-5 leading-[140%]">
         <div className="mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
-          <Image src={DefaultAvatar} alt="프로필 아바타" width={110} height={110} />
+          <Image
+            src={profileImageUrl || DefaultAvatar}
+            alt="프로필 아바타"
+            width={110}
+            height={110}
+          />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/components/mypage/dashboard/ProfileEditModal.tsx
+++ b/components/mypage/dashboard/ProfileEditModal.tsx
@@ -16,6 +16,7 @@ interface ProfileEditModalProps {
   onWithdrawClick: () => void;
   username: string;
   nickname: string;
+  profileImageUrl?: string | null;
 }
 
 export function ProfileEditModal({
@@ -24,6 +25,7 @@ export function ProfileEditModal({
   onWithdrawClick,
   username,
   nickname,
+  profileImageUrl,
 }: ProfileEditModalProps) {
   const [displayName, setDisplayName] = useState(nickname);
   const router = useRouter();
@@ -65,7 +67,12 @@ export function ProfileEditModal({
           </h2>
 
           <div className="mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
-            <Image src={DefaultAvatar} alt="프로필 아바타" width={110} height={110} />
+            <Image
+              src={profileImageUrl || DefaultAvatar}
+              alt="프로필 아바타"
+              width={110}
+              height={110}
+            />
           </div>
 
           <div className="flex flex-col gap-2.5">

--- a/components/mypage/observations/ObservationsBoundary.tsx
+++ b/components/mypage/observations/ObservationsBoundary.tsx
@@ -9,14 +9,16 @@ export default function ObservationsBoundary() {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="flex items-center gap-4 bg-white px-4 py-3 md:px-9 xl:hidden">
+    <div className="flex flex-col gap-2 xl:gap-3">
+      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>
-        <h1 className="text-base font-semibold text-black md:text-[18px]">관찰일지 내역</h1>
+        <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">관찰일지 내역</h1>
       </div>
-      <h1 className="hidden text-lg font-semibold text-black xl:block">관찰일지 내역</h1>
+      <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">
+        관찰일지 내역
+      </h1>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/observations/ObservationsBoundary.tsx
+++ b/components/mypage/observations/ObservationsBoundary.tsx
@@ -10,7 +10,7 @@ export default function ObservationsBoundary() {
 
   return (
     <div className="flex flex-col gap-2 xl:gap-3">
-      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
+      <div className="flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>

--- a/components/mypage/posts/PostsBoundary.tsx
+++ b/components/mypage/posts/PostsBoundary.tsx
@@ -19,14 +19,14 @@ export default function PostsBoundary() {
   const [activeTab, setActiveTab] = useState('moabang');
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="flex items-center gap-4 bg-white px-4 py-3 md:px-9 xl:hidden">
+    <div className="flex flex-col gap-2 xl:gap-3">
+      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>
-        <h1 className="text-base font-semibold text-black md:text-[18px]">게시글</h1>
+        <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">게시글</h1>
       </div>
-      <h1 className="hidden text-lg font-semibold text-black xl:block">게시글</h1>
+      <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">게시글</h1>
 
       <div className="mx-4 flex h-10 items-stretch rounded-lg bg-black-200 px-5 md:mx-9 xl:mx-0">
         <Tabs

--- a/components/mypage/posts/PostsBoundary.tsx
+++ b/components/mypage/posts/PostsBoundary.tsx
@@ -20,7 +20,7 @@ export default function PostsBoundary() {
 
   return (
     <div className="flex flex-col gap-2 xl:gap-3">
-      <div className="md:9 flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
+      <div className="flex items-center gap-4 px-4 pt-4 md:px-9 md:pt-9 xl:hidden">
         <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
           <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -147,7 +147,10 @@ export default function ObservationCreateForm() {
                     onClick={() => setAreaBottomSheetOpen(true)}
                     className="flex w-full items-center justify-between rounded-lg border border-black-300 p-2.5 text-sm font-medium text-black-800"
                   >
-                    <span>5개 영역</span>
+                    <span className="flex items-center gap-1">
+                      5개 영역
+                      <span className="text-xs font-medium text-black-500">중복선택 가능</span>
+                    </span>
                     <ChevronDownIcon width={20} height={20} className="shrink-0" />
                   </button>
                   <SelectBottomSheet
@@ -186,6 +189,7 @@ export default function ObservationCreateForm() {
                     size="md"
                     options={AREA_OPTIONS}
                     triggerLabel="5개 영역"
+                    triggerDescription="중복선택 가능"
                     value={areas}
                     onChange={setAreas}
                     className="w-full md:w-90"

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
@@ -21,6 +21,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { toast } from '@/utils/toast';
 import { useLoginModalStore } from '@/stores/loginModalStore';
 import { useUserStore } from '@/stores/userStore';
+import { useObservationStore } from '@/stores/observationStore';
 
 export default function ObservationCreateForm() {
   const router = useRouter();
@@ -37,6 +38,11 @@ export default function ObservationCreateForm() {
   const isMobile = useIsMobile();
   const user = useUserStore((state) => state.user);
   const openLoginModal = useLoginModalStore((state) => state.open);
+  const setIsGenerating = useObservationStore((state) => state.setIsGenerating);
+
+  useEffect(() => {
+    return () => setIsGenerating(false);
+  }, [setIsGenerating]);
 
   const { mutate: createObservation, isPending: isMutating } = useObservationMutation({
     onSuccess: ({ observationId }) => {
@@ -48,6 +54,7 @@ export default function ObservationCreateForm() {
       });
     },
     onError: (error) => {
+      setIsGenerating(false);
       if (axios.isAxiosError(error) && error.response?.data?.code === 'CREDIT_NOT_ENOUGH') {
         setShowCreditDialog(true);
       } else if (!(error as { isHandled?: boolean }).isHandled) {
@@ -83,6 +90,7 @@ export default function ObservationCreateForm() {
       openLoginModal('로그인이 필요해요!', '로그인 후 관찰일지를 생성할 수 있어요');
       return;
     }
+    setIsGenerating(true);
     createObservation({ age, sectionTypes: areas, situation: content });
   };
 

--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -109,7 +109,7 @@ export default function ObservationCreateForm() {
         ]}
       />
       <div className="flex flex-col items-center">
-        <div className="mb-5 text-center md:mb-12.5">
+        <div className="mt-15 mb-5 text-center md:mt-6 md:mb-12.5 xl:mt-0">
           <h1 className="text-base font-semibold text-black md:text-xl">
             관찰일지를
             <br className="md:hidden" />

--- a/components/observations/ObservationCreditBadgeWrapper.tsx
+++ b/components/observations/ObservationCreditBadgeWrapper.tsx
@@ -4,14 +4,17 @@ import { usePathname } from 'next/navigation';
 import { ObservationCreditBadge } from '@/components/common/observation-credit-badge/ObservationCreditBadge';
 import { useCreditsQuery } from '@/hooks/queries/user/useCredits';
 import { useUserStore } from '@/stores/userStore';
+import { useObservationStore } from '@/stores/observationStore';
 
 export function ObservationCreditBadgeWrapper() {
   const pathname = usePathname();
   const user = useUserStore((state) => state.user);
   const { data: credits } = useCreditsQuery(!!user);
+  const isGenerating = useObservationStore((state) => state.isGenerating);
 
   if (!user) return null;
   if (pathname !== '/observations') return null;
+  if (isGenerating) return null;
 
   return <ObservationCreditBadge remainingCount={credits?.balance ?? 0} />;
 }

--- a/components/observations/ObservationDetail.tsx
+++ b/components/observations/ObservationDetail.tsx
@@ -7,6 +7,7 @@ import ObservationResultCard from '@/components/observations/ObservationResultCa
 import ObservationLoading from '@/components/observations/ObservationLoading';
 import { Button } from '@/components/common/button/Button';
 import { Dialog } from '@/components/common/dialog/Dialog';
+import { ChevronDownIcon } from '@/app/assets/icons';
 import { SECTION_TYPE_LABEL } from '@/constants/observations/observation';
 import { toast } from '@/utils/toast';
 import {
@@ -68,6 +69,14 @@ export default function ObservationDetail({ observationId }: ObservationDetailPr
         ]}
       />
       <div>
+        <div className="mb-2 flex items-center gap-4 xl:hidden">
+          <button type="button" onClick={() => router.back()} aria-label="뒤로가기">
+            <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
+          </button>
+          <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">
+            {observation.title}
+          </h1>
+        </div>
         <div className="flex flex-col gap-5">
           {items.map((item) => (
             <ObservationResultCard key={item.title} title={item.title} content={item.content} />

--- a/stores/observationStore.ts
+++ b/stores/observationStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ObservationStore {
+  isGenerating: boolean;
+  setIsGenerating: (value: boolean) => void;
+}
+
+export const useObservationStore = create<ObservationStore>((set) => ({
+  isGenerating: false,
+  setIsGenerating: (value) => set({ isGenerating: value }),
+}));


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 과정에서 확인된 버그 수정 및 UX 개선
 
- ## 주요 변경(무엇을?):
  - 마이페이지, 관찰일지, 네비게이션 UI 반응형 수정 및 기능 보완

## 변경 내용

  - [x] 마이페이지 댓글 목록에 카테고리 표시 추가
  - [x] 관찰일지 생성 로딩 중 생성 횟수 배지 숨김 처리
  - [x] 모바일/태블릿 관찰일지 결과 페이지 타이틀 및 뒤로가기 표시
  - [x] 네비게이션 메뉴 최근 관찰일지 개수 표시
  - [x] 5개 영역 셀렉트 중복선택 가능 문구 추가
  - [x] 단일 선택 셀렉트 선택 후 자동 닫힘 처리
  - [x] 바텀시트 자동 포커스 방지로 iOS 키보드 자동 노출 문제 해결
  - [x] 프로필 편집 모달/바텀시트에 실제 프로필 이미지 표시
  - [x] 마이페이지 서브 헤더 높이 및 여백 통일
  - [x] 로그아웃 성공/실패 시 토스트 메시지 노출
  - [x] 모바일 햄버거 메뉴 로그아웃 시 메뉴 닫힘 처리
  - [x] AI 관찰일지 레이아웃 패딩 조정

### 세부 변경 사항

- 바텀시트 열릴 때 autoFocus 방지 → iOS에서 키보드 자동 노출 버그 해결
- 세션 만료 시 refresh token으로 자동 갱신 처리
- 마이페이지 레이아웃 패딩 커뮤니티 타이틀 기준으로 통일

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #120 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added badge count indicator for recent observations in navigation
  * Added mobile header with back button on observation detail pages
  * Added select trigger descriptions support

* **Improvements**
  * Toast notifications now display on logout success/error
  * Comments display localized category labels instead of raw values
  * Profile image preview displays in edit modal
  * Dropdown menus close properly on selection
  * Observation form displays "multiple selection possible" messaging
  * Bottom sheet prevents unwanted auto-focus behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->