### PR TITLE
Fix: 0.1.2 QA 버그 수정 (#126)

### DIFF
--- a/api/auth.api.ts
+++ b/api/auth.api.ts
@@ -1,9 +1,5 @@
 import apiClient from './axios';
 
-export const refresh = async (): Promise<void> => {
-  await apiClient.post('/api/v1/auth/refresh');
-};
-
 export const logout = async (): Promise<void> => {
   try {
     await apiClient.post('/api/v1/auth/logout');

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -70,11 +70,14 @@ apiClient.interceptors.response.use(
       if (!res.ok) throw new Error('refresh failed');
 
       const { data } = await res.json();
-      await fetch('/api/auth/set-token', {
+      if (!data?.accessToken) throw new Error('refresh failed');
+
+      const setTokenRes = await fetch('/api/auth/set-token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ accessToken: data.accessToken }),
       });
+      if (!setTokenRes.ok) throw new Error('set-token failed');
 
       processPendingQueue(null);
       return apiClient(originalRequest);

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -45,6 +45,7 @@ apiClient.interceptors.response.use(
 
     if (!document.cookie.split(';').some((c) => c.trim() === 'isLoggedIn=true')) {
       error.isHandled = true;
+      useLoginModalStore.getState().open();
       return Promise.reject(error);
     }
 

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -66,6 +66,7 @@ apiClient.interceptors.response.use(
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/refresh`, {
         method: 'POST',
         credentials: 'include',
+        signal: AbortSignal.timeout(10000),
       });
       if (!res.ok) throw new Error('refresh failed');
 
@@ -76,6 +77,7 @@ apiClient.interceptors.response.use(
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ accessToken: data.accessToken }),
+        signal: AbortSignal.timeout(10000),
       });
       if (!setTokenRes.ok) throw new Error('set-token failed');
 

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { useLoginModalStore } from '@/stores/loginModalStore';
+import { useUserStore } from '@/stores/userStore';
 
 const apiClient = axios.create({
   baseURL: '/api/proxy',
@@ -38,6 +39,10 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    if (originalRequest.url?.includes('/api/v1/auth/refresh')) {
+      return Promise.reject(error);
+    }
+
     if (isLoggingOut) {
       error.isHandled = true;
       return Promise.reject(error);
@@ -68,6 +73,7 @@ apiClient.interceptors.response.use(
     } catch (refreshError) {
       processPendingQueue(refreshError);
       await fetch('/api/auth/logout', { method: 'POST' });
+      useUserStore.getState().setUser(null);
       useLoginModalStore.getState().open('세션이 만료되었어요!', '다시 로그인해 주세요');
       if (axios.isAxiosError(refreshError)) refreshError.isHandled = true;
       return Promise.reject(refreshError);

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -85,7 +85,11 @@ apiClient.interceptors.response.use(
       return apiClient(originalRequest);
     } catch (refreshError) {
       processPendingQueue(refreshError);
-      await fetch('/api/auth/logout', { method: 'POST' });
+      try {
+        await fetch('/api/auth/logout', { method: 'POST' });
+      } catch {
+        // 로그아웃 요청이 실패해도 로컬 상태는 정리한다
+      }
       useUserStore.getState().setUser(null);
       useLoginModalStore.getState().open('세션이 만료되었어요!', '다시 로그인해 주세요');
       if (axios.isAxiosError(refreshError)) refreshError.isHandled = true;

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -39,10 +39,6 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (originalRequest.url?.includes('/api/v1/auth/refresh')) {
-      return Promise.reject(error);
-    }
-
     if (isLoggingOut) {
       error.isHandled = true;
       return Promise.reject(error);
@@ -67,7 +63,19 @@ apiClient.interceptors.response.use(
     isRefreshing = true;
 
     try {
-      await apiClient.post('/api/v1/auth/refresh');
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('refresh failed');
+
+      const { data } = await res.json();
+      await fetch('/api/auth/set-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accessToken: data.accessToken }),
+      });
+
       processPendingQueue(null);
       return apiClient(originalRequest);
     } catch (refreshError) {

--- a/app/api/auth/set-token/route.ts
+++ b/app/api/auth/set-token/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
-  const { accessToken } = await req.json();
+  if (req.headers.get('origin') !== req.nextUrl.origin) {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+
+  let accessToken: unknown;
+  try {
+    ({ accessToken } = await req.json());
+  } catch {
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
 
   if (!accessToken || typeof accessToken !== 'string') {
     return NextResponse.json({ success: false }, { status: 400 });

--- a/app/api/auth/set-token/route.ts
+++ b/app/api/auth/set-token/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { accessToken } = await req.json();
+
+  if (!accessToken || typeof accessToken !== 'string') {
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
+
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set('accessToken', accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+  });
+
+  return response;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
       <PainPointSection />
       <SolutionSection />
       <Footer />
-      <div className="fixed right-5 bottom-17.5 z-10 md:right-20">
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
         <ScrollToTopButton showAfter={300} />
       </div>
     </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
+import axios from 'axios';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -11,6 +12,8 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 60 * 1000,
+            retry: (count, error) =>
+              axios.isAxiosError(error) && error.response?.status === 401 ? false : count < 3,
           },
         },
       }),

--- a/components/community/board/BoardSection.tsx
+++ b/components/community/board/BoardSection.tsx
@@ -88,7 +88,7 @@ function BoardListContent({
   const { data } = useBoardPostsQuery({
     headTag: category !== 'all' ? (category as HeadTag) : undefined,
     page: currentPage - 1,
-    size: 9,
+    size: 8,
   });
 
   return (
@@ -136,7 +136,7 @@ function BoardSearchContent({
   currentPage: number;
   onPageChange: (page: number) => void;
 }) {
-  const { data } = useBoardSearchQuery({ keyword, page: currentPage - 1, size: 9 });
+  const { data } = useBoardSearchQuery({ keyword, page: currentPage - 1, size: 8 });
 
   return (
     <>

--- a/components/community/board/BoardSection.tsx
+++ b/components/community/board/BoardSection.tsx
@@ -235,9 +235,9 @@ export default function BoardSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <BoardSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} positionClassName="fixed right-9 bottom-24 z-300" />
-      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+      <div className="fixed right-9 bottom-9 z-300 flex flex-col-reverse items-center gap-3 xl:hidden">
         <ScrollToTopButton showAfter={300} />
+        <CommunityFab onClick={handleWrite} positionClassName="" />
       </div>
       {!keyword && (
         <CommunityFilter

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -132,7 +132,11 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
             title={title}
             showBackButton
             actions={
-              <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
+              <AsyncBoundary
+                pendingFallback={null}
+                rejectedFallback={() => null}
+                authErrorFallback={false}
+              >
                 <BoardDetailHeaderActions
                   postId={postId}
                   onEdit={handleEdit}
@@ -157,7 +161,11 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
           </AsyncBoundary>
         </div>
         <div className="sticky top-[263.2px] hidden shrink-0 xl:block">
-          <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
+          <AsyncBoundary
+            pendingFallback={null}
+            rejectedFallback={() => null}
+            authErrorFallback={false}
+          >
             <BoardDetailSideActionsLoader postId={postId} />
           </AsyncBoundary>
         </div>

--- a/components/community/moabang/MoabangSection.tsx
+++ b/components/community/moabang/MoabangSection.tsx
@@ -243,9 +243,9 @@ export default function MoabangSection() {
         onSearch={handleSearch}
         renderSearchResults={(kw) => <MoabangSearchInfinite keyword={kw} />}
       />
-      <CommunityFab onClick={handleWrite} positionClassName="fixed right-9 bottom-24 z-300" />
-      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+      <div className="fixed right-9 bottom-9 z-300 flex flex-col-reverse items-center gap-3 xl:hidden">
         <ScrollToTopButton showAfter={300} />
+        <CommunityFab onClick={handleWrite} positionClassName="" />
       </div>
       {!keyword && (
         <CommunityFilter

--- a/components/community/write/WriteEditor.tsx
+++ b/components/community/write/WriteEditor.tsx
@@ -680,8 +680,10 @@ function MobileColorPalette({
           className="h-6 w-6 shrink-0 rounded border border-black-200 shadow-sm"
           style={{ backgroundColor: previewColor }}
         />
-        <div className="flex h-6 items-center rounded border border-black-200 bg-white px-1.5 focus-within:border-black-400">
-          <span className={`text-xs ${hexInput.length > 0 ? 'text-black-800' : 'text-black-300'}`}>
+        <div className="flex h-8 items-center rounded border border-black-200 bg-white px-1.5 focus-within:border-black-400">
+          <span
+            className={`text-base ${hexInput.length > 0 ? 'text-black-800' : 'text-black-300'}`}
+          >
             #
           </span>
           <input
@@ -695,7 +697,7 @@ function MobileColorPalette({
               if (!isValidHex) setHexInput(activeColor.replace('#', ''));
             }}
             placeholder="000000"
-            className="w-14 bg-transparent text-xs text-black-800 outline-none placeholder:text-black-300"
+            className="w-16 bg-transparent text-base text-black-800 outline-none placeholder:text-black-300"
           />
         </div>
         <button

--- a/components/community/write/WriteFileUpload.tsx
+++ b/components/community/write/WriteFileUpload.tsx
@@ -110,8 +110,8 @@ export default function WriteFileUpload({
         </Button>
         <div className="flex items-center gap-2">
           <span className="text-xs text-black-500">
-            현재 {totalBytes === 0 ? '0' : (totalBytes / (1024 * 1024)).toFixed(1)}MB / 전체{' '}
-            {MAX_SIZE_MB}MB
+            현재 {totalBytes < 1024 * 1024 * 0.1 ? '0' : (totalBytes / (1024 * 1024)).toFixed(1)}MB
+            / 전체 {MAX_SIZE_MB}MB
           </span>
         </div>
         <input

--- a/components/community/write/write-selects.ts
+++ b/components/community/write/write-selects.ts
@@ -6,6 +6,7 @@ export const BOARD_OPTIONS: SelectOption[] = [
 ];
 
 export const AGE_OPTIONS: SelectOption[] = [
+  { label: '공통', value: 'ALL' },
   { label: '영아', value: 'INFANT' },
   { label: '만 3세', value: 'AGE_3' },
   { label: '만 4세', value: 'AGE_4' },

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -31,7 +31,7 @@ function CreditBadge() {
 function LoggedInHero({ userName = '' }: { userName: string }) {
   return (
     <div className="relative flex w-full flex-col items-center px-4 pt-10 pb-5.75 md:px-8 md:py-15 xl:px-0">
-      <AsyncBoundary pendingFallback={null} rejectedFallback={() => null}>
+      <AsyncBoundary pendingFallback={null} rejectedFallback={() => null} authErrorFallback={false}>
         <CreditBadge />
       </AsyncBoundary>
 

--- a/components/home/ServiceCard.tsx
+++ b/components/home/ServiceCard.tsx
@@ -35,9 +35,9 @@ export default function ServiceCard({
       <Image
         src={characterHoverSrc}
         alt=""
-        width={130}
-        height={145}
-        className="absolute top-0 right-3.75 z-5 opacity-0 transition-opacity group-hover:z-11 group-hover:opacity-100 max-md:h-23.5 max-md:w-25 md:right-2"
+        width={110}
+        height={118}
+        className="absolute top-1.5 right-7 z-5 opacity-0 transition-opacity group-hover:z-11 group-hover:opacity-100 max-md:h-19.5 max-md:w-18 md:right-5"
       />
 
       <div className="relative flex h-28.25 w-full flex-col md:h-49.75">

--- a/components/home/ServiceCard.tsx
+++ b/components/home/ServiceCard.tsx
@@ -37,7 +37,7 @@ export default function ServiceCard({
         alt=""
         width={130}
         height={145}
-        className="absolute top-0 right-3.75 z-5 opacity-0 transition-opacity group-hover:z-10 group-hover:opacity-100 max-md:h-23.5 max-md:w-25 md:right-2"
+        className="absolute top-0 right-3.75 z-5 opacity-0 transition-opacity group-hover:z-11 group-hover:opacity-100 max-md:h-23.5 max-md:w-25 md:right-2"
       />
 
       <div className="relative flex h-28.25 w-full flex-col md:h-49.75">

--- a/constants/community/community-tabs.ts
+++ b/constants/community/community-tabs.ts
@@ -3,7 +3,7 @@ import type { TabOption } from '@/components/common/tabs/Tabs';
 const ALL_TAB: TabOption = { label: '전체', value: 'all' };
 
 export const MOABANG_AGES: TabOption[] = [
-  { label: '전체 연령', value: 'ALL' },
+  { label: '공통', value: 'ALL' },
   { label: '영아', value: 'INFANT' },
   { label: '만 3세', value: 'AGE_3' },
   { label: '만 4세', value: 'AGE_4' },

--- a/hooks/queries/community/useCommunity.ts
+++ b/hooks/queries/community/useCommunity.ts
@@ -88,7 +88,7 @@ export function useMoabangSearchInfiniteQuery(params: Omit<MoabangSearchParams, 
 export function useBoardPostsInfiniteQuery(params: Omit<BoardListParams, 'page'>) {
   return useSuspenseInfiniteQuery({
     queryKey: ['board', 'posts', 'infinite', params],
-    queryFn: ({ pageParam }) => getBoardPosts({ ...params, page: pageParam as number, size: 9 }),
+    queryFn: ({ pageParam }) => getBoardPosts({ ...params, page: pageParam as number, size: 8 }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
   });
@@ -97,7 +97,7 @@ export function useBoardPostsInfiniteQuery(params: Omit<BoardListParams, 'page'>
 export function useBoardSearchInfiniteQuery(params: Omit<BoardSearchParams, 'page'>) {
   return useInfiniteQuery({
     queryKey: ['board', 'search', 'infinite', params],
-    queryFn: ({ pageParam }) => searchBoardPosts({ ...params, page: pageParam as number, size: 9 }),
+    queryFn: ({ pageParam }) => searchBoardPosts({ ...params, page: pageParam as number, size: 8 }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     placeholderData: keepPreviousData,

--- a/lib/async-boundary/AsyncBoundary.tsx
+++ b/lib/async-boundary/AsyncBoundary.tsx
@@ -1,20 +1,53 @@
 'use client';
 
-import { ErrorBoundary, Suspense } from '@suspensive/react';
+import { ErrorBoundary, type ErrorBoundaryFallbackProps, Suspense } from '@suspensive/react';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
 import type { ComponentPropsWithoutRef } from 'react';
+import { ErrorFallback } from './AsyncBoundaryFallbacks';
 
 type Props = {
   pendingFallback?: ComponentPropsWithoutRef<typeof Suspense>['fallback'];
   rejectedFallback: ComponentPropsWithoutRef<typeof ErrorBoundary>['fallback'];
+  authErrorFallback?: boolean;
   children: React.ReactNode;
 };
 
-export function AsyncBoundary({ pendingFallback, rejectedFallback, children }: Props) {
+export function AsyncBoundary({
+  pendingFallback,
+  rejectedFallback,
+  authErrorFallback = true,
+  children,
+}: Props) {
+  const router = useRouter();
+
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary fallback={rejectedFallback} onReset={reset}>
+        <ErrorBoundary
+          onReset={reset}
+          fallback={(props: ErrorBoundaryFallbackProps) => {
+            const { error } = props;
+            if (authErrorFallback && axios.isAxiosError(error) && error.response?.status === 401) {
+              return (
+                <ErrorFallback
+                  error={error}
+                  title="로그인이 필요해요"
+                  description="로그인 후 이용할 수 있어요"
+                  actionLabel="돌아가기"
+                  onAction={() => router.back()}
+                  className="mt-[15vh]"
+                />
+              );
+            }
+            if (typeof rejectedFallback === 'function') {
+              const RejectedFallback = rejectedFallback;
+              return <RejectedFallback {...props} />;
+            }
+            return rejectedFallback;
+          }}
+        >
           <Suspense clientOnly fallback={pendingFallback}>
             {children}
           </Suspense>

--- a/lib/async-boundary/AsyncBoundary.tsx
+++ b/lib/async-boundary/AsyncBoundary.tsx
@@ -35,8 +35,8 @@ export function AsyncBoundary({
                   error={error}
                   title="로그인이 필요해요"
                   description="로그인 후 이용할 수 있어요"
-                  actionLabel="돌아가기"
-                  onAction={() => router.back()}
+                  actionLabel="홈으로"
+                  onAction={() => router.push('/')}
                   className="mt-[15vh]"
                 />
               );

--- a/lib/async-boundary/AsyncBoundaryFallbacks.tsx
+++ b/lib/async-boundary/AsyncBoundaryFallbacks.tsx
@@ -25,11 +25,21 @@ type ErrorFallbackProps = {
   error: Error & { response?: { data?: { detail?: string } } };
   actionLabel: string;
   onAction: () => void;
+  title?: string;
+  description?: string;
   className?: string;
 };
 
-export function ErrorFallback({ error, actionLabel, onAction, className }: ErrorFallbackProps) {
-  const errorMessage = error.response?.data?.detail ?? error.message;
+export function ErrorFallback({
+  error,
+  actionLabel,
+  onAction,
+  title,
+  description,
+  className,
+}: ErrorFallbackProps) {
+  const resolvedTitle = title ?? '문제가 발생했어요';
+  const resolvedDescription = description ?? error.response?.data?.detail ?? error.message;
 
   return (
     <div className={`flex flex-col items-center gap-4.5 ${className ?? ''}`}>
@@ -42,8 +52,8 @@ export function ErrorFallback({ error, actionLabel, onAction, className }: Error
       />
       <div className="flex w-52.5 flex-col items-center gap-4.5">
         <div className="flex flex-col items-center gap-2 px-2 text-center">
-          <p className="text-base font-semibold text-black md:text-xl">문제가 발생했어요</p>
-          <p className="text-xs text-black-500 md:text-sm">{errorMessage}</p>
+          <p className="text-base font-semibold text-black md:text-xl">{resolvedTitle}</p>
+          <p className="text-xs text-black-500 md:text-sm">{resolvedDescription}</p>
         </div>
         <Button size="full" className="bg-green-500 hover:bg-green-700" onClick={onAction}>
           {actionLabel}


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 0.1.2 QA 과정에서 발견된 버그들을 수정 하기 위해 작업 하였습니다.
- ## 주요 변경(무엇을?):
  - 각 섹션별 버그들 

## 변경 내용

- [x] 수정 사항 반영

### 세부 변경 사항

- 토큰 자동 갱신(refresh) 복구 -> 30분 후 강제 로그아웃문제 해결
- refresh 갱신용 accessToken 쿠키 저장 라우트 추가
- 자유게시판 페이지네이션 9 → 8로 수정
- 비로그인 상태에서 401 시 로그인 모달 노출
- 홈 모아방 페이지에 맞춰 스크롤 탑 버튼 위치 수정
- Fab 위치와 스크롤 탑 버튼 위치 수정
- 서비스 카드 이미지 캐릭터 크기 및 z-index 수정
- 카테고리탭, 연령 옵션 수정
- 파일 업로드 0.1MB 이하는 0으로 표기
- iOS 텍스트 에디터 hex 컬러 input zoom 버그 수정

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Common" option to age filter for community posts.

* **Bug Fixes**
  * Enhanced session expiration handling with improved login prompts.

* **Style**
  * Optimized mobile layout positioning for action buttons.
  * Increased color picker input size for improved usability.
  * Refined service card hover image scaling.
  * Improved file upload size display formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->