### PR TITLE
Fix: 0.1.2 QA 버그 수정 (#127)

### DIFF
--- a/components/observations/ObservationCreateForm.tsx
+++ b/components/observations/ObservationCreateForm.tsx
@@ -46,6 +46,7 @@ export default function ObservationCreateForm() {
 
   const { mutate: createObservation, isPending: isMutating } = useObservationMutation({
     onSuccess: ({ observationId }) => {
+      queryClient.invalidateQueries({ queryKey: ['credits'] });
       queryClient.invalidateQueries({ queryKey: ['observations'] });
       queryClient.invalidateQueries({ queryKey: ['myObservations'] });
       queryClient.invalidateQueries({ queryKey: ['activitySummary'] });

--- a/components/observations/ObservationDetail.tsx
+++ b/components/observations/ObservationDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import ObservationResultCard from '@/components/observations/ObservationResultCard';
 import ObservationLoading from '@/components/observations/ObservationLoading';
@@ -21,11 +22,15 @@ interface ObservationDetailProps {
 
 export default function ObservationDetail({ observationId }: ObservationDetailProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [showCreditDialog, setShowCreditDialog] = useState(false);
 
   const { data: observation, refetch } = useObservationItemQuery(observationId);
   const { mutate: regenerate, isPending } = useObservationRegenerateMutation({
-    onSuccess: () => refetch(),
+    onSuccess: () => {
+      refetch();
+      queryClient.invalidateQueries({ queryKey: ['credits'] });
+    },
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response?.data?.code === 'CREDIT_NOT_ENOUGH') {
         setShowCreditDialog(true);

--- a/hooks/queries/community/useCommunity.ts
+++ b/hooks/queries/community/useCommunity.ts
@@ -207,6 +207,7 @@ export function useCreatePostMutation() {
       queryClient.invalidateQueries({ queryKey: [queryKey, 'posts'] });
       const myQueryKey = request.category === 'MOABANG' ? 'myMoabangPosts' : 'myFreePosts';
       queryClient.invalidateQueries({ queryKey: [myQueryKey] });
+      queryClient.invalidateQueries({ queryKey: ['credits'] });
     },
   });
 }


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 과정에서 확인된 버그 수정
- ## 주요 변경(무엇을?):
  - 크레딧이 변동되는 mutation의 onSuccess에서 ['credits'] 쿼리를 무효화하도록 추가

## 변경 내용

- [x] 관찰일지 생성 후 크레딧 배지 미갱신 수정
- [x] 관찰일지 재생성 후 크레딧 배지 미갱신 수정
- [x] 커뮤니티 글 작성 후 크레딧 배지 갱신 처리

### 세부 변경 사항

- ObservationCreateForm
  - 생성 성공 시 invalidateQueries(['credits']) 추가
- ObservationDetail
  - 재생성 성공 시 invalidateQueries(['credits']) 추가
  - 기존 refetch와 함께 크레딧 정보도 갱신되도록 수정
- useCreatePostMutation
  - 글 작성 성공 시 invalidateQueries(['credits']) 추가
  - 글 작성 시 충전되는 생성횟수가 즉시 반영되도록 수정

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [ ] 유닛 테스트 추가/수정됨
- [ ] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Credit balances now refresh automatically after creating observations
* Credit balances now refresh automatically after regenerating observations
* Credit balances now refresh automatically after creating community posts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->