### PR TITLE
Fix: 0.1.3 QA 버그 수정 (#132)

### DIFF
--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -117,7 +117,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
 
   const { mutate: deleteObservation } = useObservationDeleteMutation({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: observationKeys.recent() });
+      queryClient.invalidateQueries({ queryKey: observationKeys.all });
       queryClient.invalidateQueries({ queryKey: userKeys.myObservations.all });
       queryClient.invalidateQueries({ queryKey: userKeys.activitySummary() });
       toast.success({

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -94,7 +94,7 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
   useEffect(() => {
     const listKey = title === '모아방' ? 'moabang' : 'board';
     return () => {
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts(listKey) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board(listKey) });
     };
   }, [queryClient, title]);
   const isLoggedIn = user !== null;

--- a/components/mypage/observations/ObservationsSection.tsx
+++ b/components/mypage/observations/ObservationsSection.tsx
@@ -96,6 +96,7 @@ function ObservationsPaginated() {
     onSuccess: () => {
       refetch();
       queryClient.invalidateQueries({ queryKey: observationKeys.all });
+      queryClient.invalidateQueries({ queryKey: userKeys.myObservations.all });
       queryClient.invalidateQueries({ queryKey: userKeys.activitySummary() });
       toast.success({
         title: '관찰일지 삭제가 완료되었어요',
@@ -155,6 +156,7 @@ function ObservationsInfinite() {
     onSuccess: () => {
       refetch();
       queryClient.invalidateQueries({ queryKey: observationKeys.all });
+      queryClient.invalidateQueries({ queryKey: userKeys.myObservations.all });
       queryClient.invalidateQueries({ queryKey: userKeys.activitySummary() });
       toast.success({
         title: '관찰일지 삭제가 완료되었어요',

--- a/hooks/queries/community/queryKeys.ts
+++ b/hooks/queries/community/queryKeys.ts
@@ -2,7 +2,7 @@ type BoardType = 'moabang' | 'board';
 
 export const communityKeys = {
   postDetail: (postId: number) => ['post', 'detail', postId] as const,
-  posts: (board: BoardType) => [board, 'posts'] as const,
+  board: (board: BoardType) => [board] as const,
   postsList: (board: BoardType, params: unknown) => [board, 'posts', params] as const,
   postsInfinite: (board: BoardType, params: unknown) =>
     [board, 'posts', 'infinite', params] as const,

--- a/hooks/queries/community/useCommunity.ts
+++ b/hooks/queries/community/useCommunity.ts
@@ -113,6 +113,8 @@ export function useCreateCommentMutation(postId: number) {
     mutationFn: (content: string) => createComment(postId, { content }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityKeys.postDetail(postId) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
       queryClient.invalidateQueries({ queryKey: userKeys.myComments.all });
     },
   });
@@ -126,6 +128,8 @@ export function useUpdateCommentMutation(postId: number) {
       updateComment(postId, commentId, { content }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityKeys.postDetail(postId) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
       queryClient.invalidateQueries({ queryKey: userKeys.myComments.all });
     },
   });
@@ -138,6 +142,8 @@ export function useDeleteCommentMutation(postId: number) {
     mutationFn: (commentId: number) => deleteComment(postId, commentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityKeys.postDetail(postId) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
       queryClient.invalidateQueries({ queryKey: userKeys.myComments.all });
     },
   });
@@ -150,8 +156,8 @@ export function useLikeMutation(postId: number) {
     mutationFn: (isLiked: boolean) => (isLiked ? unlikePost(postId) : likePost(postId)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityKeys.postDetail(postId) });
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts('moabang') });
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts('board') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
     },
   });
 }
@@ -164,6 +170,8 @@ export function useBookmarkMutation(postId: number) {
       isBookmarked ? unbookmarkPost(postId) : bookmarkPost(postId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: communityKeys.postDetail(postId) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
       queryClient.invalidateQueries({ queryKey: userKeys.myBookmarks.all });
       queryClient.invalidateQueries({ queryKey: userKeys.activitySummary() });
     },
@@ -179,7 +187,7 @@ export function useUpdatePostMutation(postId: number) {
     onSuccess: (_, { request }) => {
       queryClient.removeQueries({ queryKey: communityKeys.postDetail(postId) });
       const listKey = request.category === 'MOABANG' ? 'moabang' : 'board';
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts(listKey) });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board(listKey) });
     },
   });
 }
@@ -190,8 +198,8 @@ export function useDeletePostMutation() {
   return useMutation({
     mutationFn: (postId: number) => deletePost(postId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts('moabang') });
-      queryClient.invalidateQueries({ queryKey: communityKeys.posts('board') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
       queryClient.invalidateQueries({ queryKey: userKeys.myMoabangPosts.all });
       queryClient.invalidateQueries({ queryKey: userKeys.myFreePosts.all });
     },
@@ -207,7 +215,7 @@ export function useCreatePostMutation() {
     onSuccess: (_, { request }) => {
       const isMoabang = request.category === 'MOABANG';
       queryClient.invalidateQueries({
-        queryKey: communityKeys.posts(isMoabang ? 'moabang' : 'board'),
+        queryKey: communityKeys.board(isMoabang ? 'moabang' : 'board'),
       });
       queryClient.invalidateQueries({
         queryKey: isMoabang ? userKeys.myMoabangPosts.all : userKeys.myFreePosts.all,


### PR DESCRIPTION
## 요약

  - ## 변경 목적(왜?):
    - QA 과정에서 확인된 버그 수정

  - ## 주요 변경(무엇을?):
    - 좋아요·북마크·댓글·게시글 mutation이 해당 게시판의 목록·검색 쿼리를 모두 무효화하도록 수정

  ## 변경 내용

  - [x] 좋아요/북마크 시 검색 결과 미반영 수정
  - [x] 북마크 시 목록 무효화 누락 추가
  - [x] 댓글 작성/수정/삭제 시 목록·검색의 댓글 수 미반영 수정
  - [x] 게시글 작성/수정/삭제 시 목록·검색 미반영 수정
  - [x] 관찰일지 삭제 시 목록 갱신 누락 수정 (NavMenu·마이페이지)

  ### 세부 변경 사항  

  - communityKeys에 `board(board)` prefix 헬퍼 추가 (`[board]` → 해당 게시판의 목록·검색·무한스크롤을 한 번에 무효화)
  - 좋아요·북마크·댓글·게시글 관련 mutation의 invalidate를 board prefix로 통일
    - 기존엔 목록(posts)만 무효화하거나 일부는 무효화 자체가 누락되어 검색/목록 미반영
  - BoardDetailSection 상세 이탈 시 무효화도 board prefix로 통일

  ## 스크린샷/동영상 (선택)

  <!-- UI 변경 있으면 첨부 -->

  ## 테스트
  
  - [ ] 유닛 테스트 추가/수정됨
  - [ ] 로컬에서 `pnpm test` 통과
  - [x] 타입체크/린트 통과 (`pnpm tsc --noEmit`, `pnpm lint`)

  ## 관련 이슈

  - close #132