### PR TITLE
Fix: 모아쌤 QA 수정 (#135)

### DIFF
--- a/api/axios.ts
+++ b/api/axios.ts
@@ -10,21 +10,43 @@ const apiClient = axios.create({
   },
 });
 
-let isRefreshing = false;
 let isLoggingOut = false;
-let pendingQueue: Array<{ resolve: () => void; reject: (error: unknown) => void }> = [];
+let refreshPromise: Promise<string> | null = null;
 
 export const setLoggingOut = (value: boolean) => {
   isLoggingOut = value;
 };
 
-const processPendingQueue = (error: unknown) => {
-  pendingQueue.forEach(({ resolve, reject }) => {
-    if (error) reject(error);
-    else resolve();
-  });
-  pendingQueue = [];
-};
+export function refreshAccessToken(): Promise<string> {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!res.ok) throw new Error('refresh failed');
+
+        const { data } = await res.json();
+        if (!data?.accessToken) throw new Error('refresh failed');
+
+        const setTokenRes = await fetch('/api/auth/set-token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ accessToken: data.accessToken }),
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!setTokenRes.ok) throw new Error('set-token failed');
+
+        return data.accessToken as string;
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+  }
+  return refreshPromise;
+}
 
 apiClient.interceptors.response.use(
   (response) => response,
@@ -50,41 +72,12 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        pendingQueue.push({
-          resolve: () => resolve(apiClient(originalRequest)),
-          reject,
-        });
-      });
-    }
-
     originalRequest._retry = true;
-    isRefreshing = true;
 
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/refresh`, {
-        method: 'POST',
-        credentials: 'include',
-        signal: AbortSignal.timeout(10000),
-      });
-      if (!res.ok) throw new Error('refresh failed');
-
-      const { data } = await res.json();
-      if (!data?.accessToken) throw new Error('refresh failed');
-
-      const setTokenRes = await fetch('/api/auth/set-token', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ accessToken: data.accessToken }),
-        signal: AbortSignal.timeout(10000),
-      });
-      if (!setTokenRes.ok) throw new Error('set-token failed');
-
-      processPendingQueue(null);
+      await refreshAccessToken();
       return apiClient(originalRequest);
     } catch (refreshError) {
-      processPendingQueue(refreshError);
       try {
         await fetch('/api/auth/logout', { method: 'POST' });
       } catch {
@@ -94,8 +87,6 @@ apiClient.interceptors.response.use(
       useLoginModalStore.getState().open('세션이 만료되었어요!', '다시 로그인해 주세요');
       if (axios.isAxiosError(refreshError)) refreshError.isHandled = true;
       return Promise.reject(refreshError);
-    } finally {
-      isRefreshing = false;
     }
   },
 );

--- a/api/community.api.ts
+++ b/api/community.api.ts
@@ -70,10 +70,14 @@ export async function deleteComment(postId: number, commentId: number): Promise<
 }
 
 async function fetchAccessToken(): Promise<string> {
-  const res = await fetch('/api/auth/token');
-  if (res.ok) {
-    const { accessToken } = await res.json();
-    if (accessToken) return accessToken;
+  try {
+    const res = await fetch('/api/auth/token');
+    if (res.ok) {
+      const { accessToken } = await res.json();
+      if (accessToken) return accessToken;
+    }
+  } catch {
+    // fall through to refresh
   }
   return refreshAccessToken();
 }

--- a/api/community.api.ts
+++ b/api/community.api.ts
@@ -89,6 +89,7 @@ async function uploadPostFormData<T>(
       url: `${process.env.NEXT_PUBLIC_API_URL}${path}`,
       data: formData,
       headers: { Authorization: `Bearer ${token}` },
+      timeout: 60_000,
     });
 
   try {

--- a/api/community.api.ts
+++ b/api/community.api.ts
@@ -1,4 +1,5 @@
-import apiClient from './axios';
+import axios from 'axios';
+import apiClient, { refreshAccessToken } from './axios';
 import type {
   MoabangListParams,
   MoabangListResponse,
@@ -68,6 +69,42 @@ export async function deleteComment(postId: number, commentId: number): Promise<
   await apiClient.delete(`/api/v1/posts/${postId}/comments/${commentId}`);
 }
 
+async function fetchAccessToken(): Promise<string> {
+  const res = await fetch('/api/auth/token');
+  if (res.ok) {
+    const { accessToken } = await res.json();
+    if (accessToken) return accessToken;
+  }
+  return refreshAccessToken();
+}
+
+async function uploadPostFormData<T>(
+  method: 'post' | 'patch',
+  path: string,
+  formData: FormData,
+): Promise<T> {
+  const send = (token: string) =>
+    axios.request<{ data: T }>({
+      method,
+      url: `${process.env.NEXT_PUBLIC_API_URL}${path}`,
+      data: formData,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+  try {
+    const token = await fetchAccessToken();
+    const { data } = await send(token);
+    return data.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      const token = await refreshAccessToken();
+      const { data } = await send(token);
+      return data.data;
+    }
+    throw error;
+  }
+}
+
 export async function updatePost(
   postId: number,
   request: UpdatePostRequest,
@@ -77,10 +114,7 @@ export async function updatePost(
   formData.append('request', new Blob([JSON.stringify(request)], { type: 'application/json' }));
   files.forEach((file) => formData.append('files', file));
 
-  const { data } = await apiClient.patch(`/api/v1/posts/${postId}`, formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return data.data;
+  return uploadPostFormData<CreatePostResponse>('patch', `/api/v1/posts/${postId}`, formData);
 }
 
 export async function deletePost(postId: number): Promise<void> {
@@ -111,8 +145,5 @@ export async function createPost(
   formData.append('request', new Blob([JSON.stringify(request)], { type: 'application/json' }));
   files.forEach((file) => formData.append('files', file));
 
-  const { data } = await apiClient.post('/api/v1/posts', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return data.data;
+  return uploadPostFormData<CreatePostResponse>('post', '/api/v1/posts', formData);
 }

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function GET(req: NextRequest) {
+  if (req.headers.get('origin') !== req.nextUrl.origin) {
+    return NextResponse.json({ accessToken: null }, { status: 403 });
+  }
+
+  const accessToken = (await cookies()).get('accessToken')?.value;
+  if (!accessToken) {
+    return NextResponse.json({ accessToken: null }, { status: 401 });
+  }
+
+  return NextResponse.json({ accessToken });
+}

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 
 export async function GET(req: NextRequest) {
-  if (req.headers.get('origin') !== req.nextUrl.origin) {
+  const fetchSite = req.headers.get('sec-fetch-site');
+  if (fetchSite && fetchSite !== 'same-origin') {
     return NextResponse.json({ accessToken: null }, { status: 403 });
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,6 +47,9 @@
   --color-yellow-100: #fff9f0;
   --color-yellow-50: #fffcf7;
 
+  /* Orange */
+  --color-orange-700: #f36012;
+
   /* Black */
   --color-black-800: #343434;
   --color-black-700: #585858;

--- a/components/common/badge/Badge.tsx
+++ b/components/common/badge/Badge.tsx
@@ -15,6 +15,7 @@ const VARIANT_STYLES: Record<BadgeVariant, string> = {
   'outline-pink': 'border border-pink-700 text-pink-700',
   'outline-green': 'border border-green-700 text-green-800',
   'outline-gray': 'border border-black-560 text-black-560',
+  'outline-orange': 'border border-orange-700 text-orange-700',
 };
 
 export default function Badge({ label, variant }: BadgeProps) {

--- a/components/common/badge/badge.type.ts
+++ b/components/common/badge/badge.type.ts
@@ -7,4 +7,5 @@ export type BadgeVariant =
   | 'outline-yellow'
   | 'outline-pink'
   | 'outline-green'
-  | 'outline-gray';
+  | 'outline-gray'
+  | 'outline-orange';

--- a/components/community/board/board-detail/BoardDetailPost.tsx
+++ b/components/community/board/board-detail/BoardDetailPost.tsx
@@ -41,6 +41,7 @@ const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   PLAN: 'outline-green',
   JOURNAL: 'outline-pink',
   NOTICE: 'outline-gray',
+  ENVIRONMENT: 'outline-yellow',
 };
 
 interface BoardDetailPostProps {

--- a/components/community/board/board-detail/BoardDetailPost.tsx
+++ b/components/community/board/board-detail/BoardDetailPost.tsx
@@ -41,7 +41,7 @@ const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   PLAN: 'outline-green',
   JOURNAL: 'outline-pink',
   NOTICE: 'outline-gray',
-  ENVIRONMENT: 'outline-yellow',
+  ENVIRONMENT: 'outline-orange',
 };
 
 interface BoardDetailPostProps {

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -16,6 +16,7 @@ import {
   communityKeys,
 } from '@/hooks/queries/community';
 import { useUserStore } from '@/stores/userStore';
+import { useLoginModalStore } from '@/stores/loginModalStore';
 import { toast } from '@/utils/toast';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
 
@@ -90,6 +91,15 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
   const router = useRouter();
   const queryClient = useQueryClient();
   const user = useUserStore((state) => state.user);
+  const openLoginModal = useLoginModalStore((state) => state.open);
+
+  useEffect(() => {
+    const isLoggedIn = document.cookie.split(';').some((c) => c.trim() === 'isLoggedIn=true');
+    if (!isLoggedIn) {
+      openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
+      router.back();
+    }
+  }, [openLoginModal, router]);
 
   useEffect(() => {
     const listKey = title === '모아방' ? 'moabang' : 'board';

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -103,11 +103,7 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
     if (authReady || redirectingRef.current) return;
     redirectingRef.current = true;
     openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
-    if (window.history.length > 1) {
-      router.back();
-    } else {
-      router.push(title === '모아방' ? '/community/moabang' : '/community/board');
-    }
+    router.push(title === '모아방' ? '/community/moabang' : '/community/board');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/common/button/Button';
@@ -93,13 +93,23 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
   const user = useUserStore((state) => state.user);
   const openLoginModal = useLoginModalStore((state) => state.open);
 
+  const [authReady] = useState(() => {
+    if (typeof document === 'undefined') return false;
+    return document.cookie.split(';').some((c) => c.trim() === 'isLoggedIn=true');
+  });
+  const redirectingRef = useRef(false);
+
   useEffect(() => {
-    const isLoggedIn = document.cookie.split(';').some((c) => c.trim() === 'isLoggedIn=true');
-    if (!isLoggedIn) {
-      openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
+    if (authReady || redirectingRef.current) return;
+    redirectingRef.current = true;
+    openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
+    if (window.history.length > 1) {
       router.back();
+    } else {
+      router.push(title === '모아방' ? '/community/moabang' : '/community/board');
     }
-  }, [openLoginModal, router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const listKey = title === '모아방' ? 'moabang' : 'board';
@@ -126,6 +136,8 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
       onError: () => toast.error({ title: '삭제 실패', description: '잠시 후 다시 시도해주세요' }),
     });
   }
+
+  if (!authReady) return <LoadingSpinner className="mt-[20vh]" />;
 
   return (
     <div>

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -103,7 +103,7 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
     if (authReady || redirectingRef.current) return;
     redirectingRef.current = true;
     openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
-    router.push(title === '모아방' ? '/community/moabang' : '/community/board');
+    router.replace(title === '모아방' ? '/community/moabang' : '/community/board');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/community/moabang/MoabangCard.tsx
+++ b/components/community/moabang/MoabangCard.tsx
@@ -21,6 +21,7 @@ const RESOURCE_TYPE_LABEL: Record<ResourceType, string> = {
   PLAN: '계획안',
   JOURNAL: '일지',
   NOTICE: '안내문',
+  ENVIRONMENT: '환경구성',
 };
 
 interface MoabangCardProps {

--- a/components/community/moabang/moabang.type.ts
+++ b/components/community/moabang/moabang.type.ts
@@ -1,5 +1,5 @@
 export type PostAge = 'ALL' | 'INFANT' | 'AGE_3' | 'AGE_4' | 'AGE_5';
-export type ResourceType = 'ACTIVITY' | 'PLAN' | 'JOURNAL' | 'NOTICE';
+export type ResourceType = 'ACTIVITY' | 'PLAN' | 'JOURNAL' | 'NOTICE' | 'ENVIRONMENT';
 
 export interface MoabangPost {
   postId: number;

--- a/components/community/write/write-selects.ts
+++ b/components/community/write/write-selects.ts
@@ -18,6 +18,7 @@ export const MATERIAL_TYPE_OPTIONS: SelectOption[] = [
   { label: '계획안', value: 'PLAN' },
   { label: '일지', value: 'JOURNAL' },
   { label: '안내문', value: 'NOTICE' },
+  { label: '환경구성', value: 'ENVIRONMENT' },
 ];
 
 export const TOPIC_OPTIONS: SelectOption[] = [

--- a/constants/community/badge-variants.ts
+++ b/constants/community/badge-variants.ts
@@ -15,7 +15,7 @@ export const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   JOURNAL: 'outline-pink',
   PLAN: 'outline-green',
   NOTICE: 'outline-gray',
-  ENVIRONMENT: 'outline-yellow',
+  ENVIRONMENT: 'outline-orange',
 };
 
 export const HEAD_TAG_VARIANT: Record<HeadTag, BadgeVariant> = {

--- a/constants/community/badge-variants.ts
+++ b/constants/community/badge-variants.ts
@@ -15,6 +15,7 @@ export const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   JOURNAL: 'outline-pink',
   PLAN: 'outline-green',
   NOTICE: 'outline-gray',
+  ENVIRONMENT: 'outline-yellow',
 };
 
 export const HEAD_TAG_VARIANT: Record<HeadTag, BadgeVariant> = {

--- a/constants/community/community-tabs.ts
+++ b/constants/community/community-tabs.ts
@@ -15,6 +15,7 @@ export const MOABANG_CATEGORIES: TabOption[] = [
   { label: '계획안', value: 'PLAN' },
   { label: '일지', value: 'JOURNAL' },
   { label: '안내문', value: 'NOTICE' },
+  { label: '환경구성', value: 'ENVIRONMENT' },
 ];
 
 export const MOABANG_AGE_FILTER_TABS: TabOption[] = [ALL_TAB, ...MOABANG_AGES];


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 버그리포트에서 발생한 에러를 수정하는 작업 입니다. 
- ## 주요 변경(무엇을?):
  - 4.5MB 이상 업로드 안되는 점 수정,  비로그인 상세 페이지 접근 가능해지는 점 수정
## 변경 내용

- [x] 4.5MB 이상 업로드 안되는 점 수정
- [x] 비로그인 상세 페이지 접근 가능해지는 점 수정
- [x] 모아방 환경구성 추가

### 세부 변경 사항

- Vercel 서버리스 함수 4.5MB body 제한을 우회하기 위해 게시글 작성/수정 업로드 요청만 프록시를 거치지 않고 백엔드로 직접 호출하도록 변경
- 비로그인 상태로 게시글 상세 진입 시 쿼리를 차단 및 진입 경로로 돌아갈 수 있도록 router.back() 기반 복귀 처리 추가.
- 모아방에 환경구성 항목 추가 (`ENUM : ENVIRONMENT`) 

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "환경구성" (ENVIRONMENT) post type with matching badge, label, select option, and tab.

* **Bug Fixes**
  * Improved token refresh and multipart upload retry behavior to handle expired tokens more reliably.
  * Client-side auth gating now shows a session-expired login modal and redirects when not authenticated.

* **Security**
  * Token endpoint now validates request origin and safely handles missing cookies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->