### PR TITLE
Fix: 상세 페이지에서 순서 목록(1. 2. 3.) 및 불렛 스타일이 사라지는 문제 (#138)

### DIFF
--- a/app/community/board/[postId]/page.tsx
+++ b/app/community/board/[postId]/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import BoardDetailBoundary from '@/components/community/board/board-detail/BoardDetailBoundary';
 
@@ -13,5 +14,7 @@ export default async function BoardDetailPage({ params }: BoardDetailPageProps) 
 
   if (!Number.isInteger(id) || id <= 0) notFound();
 
-  return <BoardDetailBoundary postId={id} title="자유게시판" />;
+  const initialAuth = (await cookies()).get('isLoggedIn')?.value === 'true';
+
+  return <BoardDetailBoundary postId={id} title="자유게시판" initialAuth={initialAuth} />;
 }

--- a/app/community/moabang/[postId]/page.tsx
+++ b/app/community/moabang/[postId]/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import BoardDetailBoundary from '@/components/community/board/board-detail/BoardDetailBoundary';
 
@@ -13,5 +14,7 @@ export default async function MoabangDetailPage({ params }: MoabangDetailPagePro
 
   if (!Number.isInteger(id) || id <= 0) notFound();
 
-  return <BoardDetailBoundary postId={id} title="모아방" />;
+  const initialAuth = (await cookies()).get('isLoggedIn')?.value === 'true';
+
+  return <BoardDetailBoundary postId={id} title="모아방" initialAuth={initialAuth} />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -171,7 +171,8 @@ html {
   display: none;
 }
 
-.prose-editor .ProseMirror p {
+.prose-editor .ProseMirror p,
+.rich-content p {
   margin: 0.25rem 0;
 }
 
@@ -183,44 +184,51 @@ html {
   height: 0;
 }
 
-.prose-editor .ProseMirror h1 {
+.prose-editor .ProseMirror h1,
+.rich-content h1 {
   font-size: 1.75rem;
   font-weight: 700;
   margin: 0.5rem 0;
 }
 
-.prose-editor .ProseMirror h2 {
+.prose-editor .ProseMirror h2,
+.rich-content h2 {
   font-size: 1.375rem;
   font-weight: 700;
   margin: 0.5rem 0;
 }
 
-.prose-editor .ProseMirror h3 {
+.prose-editor .ProseMirror h3,
+.rich-content h3 {
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0.5rem 0;
 }
 
-.prose-editor .ProseMirror ul {
+.prose-editor .ProseMirror ul,
+.rich-content ul {
   list-style-type: disc;
   padding-left: 1.5rem;
   margin: 0.25rem 0;
 }
 
-.prose-editor .ProseMirror ol {
+.prose-editor .ProseMirror ol,
+.rich-content ol {
   list-style-type: decimal;
   padding-left: 1.5rem;
   margin: 0.25rem 0;
 }
 
-.prose-editor .ProseMirror blockquote {
+.prose-editor .ProseMirror blockquote,
+.rich-content blockquote {
   border-left: 3px solid #e2e2e2;
   padding-left: 1rem;
   color: #8a8a8a;
   margin: 0.5rem 0;
 }
 
-.prose-editor .ProseMirror code {
+.prose-editor .ProseMirror code,
+.rich-content code {
   background-color: #f2f2f2;
   border-radius: 4px;
   padding: 0.1em 0.3em;
@@ -228,7 +236,8 @@ html {
   font-size: 0.85em;
 }
 
-.prose-editor .ProseMirror pre {
+.prose-editor .ProseMirror pre,
+.rich-content pre {
   background-color: #f2f2f2;
   border-radius: 8px;
   padding: 0.75rem 1rem;
@@ -236,18 +245,21 @@ html {
   overflow-x: auto;
 }
 
-.prose-editor .ProseMirror pre code {
+.prose-editor .ProseMirror pre code,
+.rich-content pre code {
   background: none;
   padding: 0;
 }
 
-.prose-editor .ProseMirror hr {
+.prose-editor .ProseMirror hr,
+.rich-content hr {
   border: none;
   border-top: 2px solid #e2e2e2;
   margin: 0.75rem 0;
 }
 
-.prose-editor .ProseMirror table {
+.prose-editor .ProseMirror table,
+.rich-content table {
   border-collapse: collapse;
   width: 100%;
   table-layout: fixed;
@@ -255,14 +267,17 @@ html {
 }
 
 .prose-editor .ProseMirror th,
-.prose-editor .ProseMirror td {
+.prose-editor .ProseMirror td,
+.rich-content th,
+.rich-content td {
   border: 1px solid #e2e2e2;
   padding: 0.4rem 0.6rem;
   min-width: 2rem;
   overflow-wrap: break-word;
 }
 
-.prose-editor .ProseMirror th {
+.prose-editor .ProseMirror th,
+.rich-content th {
   background-color: #f2f2f2;
   font-weight: 600;
 }
@@ -282,12 +297,14 @@ html {
   cursor: col-resize;
 }
 
-.prose-editor .ProseMirror mark {
+.prose-editor .ProseMirror mark,
+.rich-content mark {
   border-radius: 2px;
   padding: 0 0.1em;
 }
 
-.prose-editor .ProseMirror img {
+.prose-editor .ProseMirror img,
+.rich-content img {
   max-width: 100%;
   height: auto;
   border-radius: 4px;

--- a/components/community/board/board-detail/BoardDetailBoundary.tsx
+++ b/components/community/board/board-detail/BoardDetailBoundary.tsx
@@ -5,8 +5,13 @@ import BoardDetailSection from './BoardDetailSection';
 interface BoardDetailBoundaryProps {
   postId: number;
   title: string;
+  initialAuth: boolean;
 }
 
-export default function BoardDetailBoundary({ postId, title }: BoardDetailBoundaryProps) {
-  return <BoardDetailSection postId={postId} title={title} />;
+export default function BoardDetailBoundary({
+  postId,
+  title,
+  initialAuth,
+}: BoardDetailBoundaryProps) {
+  return <BoardDetailSection postId={postId} title={title} initialAuth={initialAuth} />;
 }

--- a/components/community/board/board-detail/BoardDetailPost.tsx
+++ b/components/community/board/board-detail/BoardDetailPost.tsx
@@ -122,7 +122,7 @@ export default function BoardDetailPost({ post }: BoardDetailPostProps) {
       <hr className="mt-5 border-black-200" />
 
       <div
-        className="mt-6 text-sm leading-relaxed font-medium text-black-700 [&_img]:h-auto [&_img]:max-w-full"
+        className="rich-content mt-6 text-sm leading-relaxed font-medium text-black-700"
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.content) }}
       />
 

--- a/components/community/board/board-detail/BoardDetailSection.tsx
+++ b/components/community/board/board-detail/BoardDetailSection.tsx
@@ -23,6 +23,7 @@ import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-bounda
 interface BoardDetailSectionProps {
   postId: number;
   title: string;
+  initialAuth: boolean;
 }
 
 function BoardDetailHeaderActions({
@@ -87,20 +88,20 @@ function BoardDetailContent({ postId, isLoggedIn }: { postId: number; isLoggedIn
   );
 }
 
-export default function BoardDetailSection({ postId, title }: BoardDetailSectionProps) {
+export default function BoardDetailSection({
+  postId,
+  title,
+  initialAuth,
+}: BoardDetailSectionProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const user = useUserStore((state) => state.user);
   const openLoginModal = useLoginModalStore((state) => state.open);
 
-  const [authReady] = useState(() => {
-    if (typeof document === 'undefined') return false;
-    return document.cookie.split(';').some((c) => c.trim() === 'isLoggedIn=true');
-  });
   const redirectingRef = useRef(false);
 
   useEffect(() => {
-    if (authReady || redirectingRef.current) return;
+    if (initialAuth || redirectingRef.current) return;
     redirectingRef.current = true;
     openLoginModal('로그인이 필요해요!', '로그인 후 게시글을 확인할 수 있어요');
     router.replace(title === '모아방' ? '/community/moabang' : '/community/board');
@@ -133,7 +134,7 @@ export default function BoardDetailSection({ postId, title }: BoardDetailSection
     });
   }
 
-  if (!authReady) return <LoadingSpinner className="mt-[20vh]" />;
+  if (!initialAuth) return <LoadingSpinner className="mt-[20vh]" />;
 
   return (
     <div>


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 중 발생 한 버그 순서목록이 상세페이지에서 표기 안되는 버그를 수정하는 작업 입니다. 
- ## 주요 변경(무엇을?):
  - 텍스트 에디터에서 작성한 글머리/번호 목록(ul, ol, li)이 상세 페이지에서 정상적으로 표시
## 변경 내용

- [x] 순서 목록 정상화

### 세부 변경 사항

- `globals.css`에 `.rich-content` 공용 선택자를 추가해 에디터(`.prose-editor.ProseMirror`)와 상세 페이지가 동일한 콘텐츠 스타일을 공유하도록 묶음.
- `BoardDetailPost`의 본문 컨테이너에 `rich-content` 클래스를 적용하고, 인라인으로 박혀 있던 `[&_img]` 제거\
- 게시글 상세 페이지의 인증 체크를 서버 쿠키 기반으로 수정 -> hydration mismatch를 제거

## 스크린샷/동영상 (선택)

<img width="571" height="474" alt="image" src="https://github.com/user-attachments/assets/d65f0c05-1e55-4ac6-861c-98ac8b390394" />


<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state handling by reading login status server-side instead of client-side for more reliable user identification.

* **Style**
  * Enhanced rich text styling consistency across the application by standardizing typography rules for all content areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->