### PR TITLE
Fix: QA 0.1.5 수정 (#150)

### DIFF
--- a/app/assets/icons/ChevronRightIcon.svg
+++ b/app/assets/icons/ChevronRightIcon.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 5 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 5 9" overflow="visible" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M0.5 8.5L4.5 4.5L0.5 0.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
       <PainPointSection />
       <SolutionSection />
       <Footer />
-      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+      <div className="fixed right-9 bottom-9 z-300">
         <ScrollToTopButton showAfter={300} />
       </div>
     </div>

--- a/components/community/CommunitySearchOverlay.tsx
+++ b/components/community/CommunitySearchOverlay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useTransition, useRef, type ReactNode } from 'react';
-import { BackArrowIcon } from '@/app/assets/icons';
+import { ChevronDownIcon } from '@/app/assets/icons';
 import { Input } from '@/components/common/input/Input';
 
 interface CommunitySearchOverlayProps {
@@ -53,7 +53,7 @@ export default function CommunitySearchOverlay({
           onClick={onClose}
           className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center"
         >
-          <BackArrowIcon />
+          <ChevronDownIcon className="h-5 w-5 rotate-90 text-black" />
         </button>
         <div className="flex-1">
           <Input

--- a/components/community/board/board-detail/BoardDetailPost.tsx
+++ b/components/community/board/board-detail/BoardDetailPost.tsx
@@ -14,8 +14,7 @@ const HEAD_TAG_LABELS: Record<string, string> = {
   FREE: '자유',
   RESOURCE: '활동자료',
   PLAN: '계획안',
-  JOURNAL: '일지',
-  NOTICE: '안내문',
+  DOCUMENT_FORM: '문서/서식',
   WORRY: '고민',
   CHAT: '잡담',
 };
@@ -38,10 +37,9 @@ const POST_AGE_VARIANT: Record<PostAge, BadgeVariant> = {
 
 const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   ACTIVITY: 'outline-yellow',
-  PLAN: 'outline-green',
-  JOURNAL: 'outline-pink',
-  NOTICE: 'outline-gray',
   ENVIRONMENT: 'outline-orange',
+  PLAN: 'outline-green',
+  DOCUMENT_FORM: 'outline-gray',
 };
 
 interface BoardDetailPostProps {

--- a/components/community/moabang/MoabangCard.tsx
+++ b/components/community/moabang/MoabangCard.tsx
@@ -18,10 +18,9 @@ const POST_AGE_LABEL: Record<PostAge, string> = {
 
 const RESOURCE_TYPE_LABEL: Record<ResourceType, string> = {
   ACTIVITY: '활동자료',
-  PLAN: '계획안',
-  JOURNAL: '일지',
-  NOTICE: '안내문',
   ENVIRONMENT: '환경구성',
+  PLAN: '계획안',
+  DOCUMENT_FORM: '문서/서식',
 };
 
 interface MoabangCardProps {

--- a/components/community/moabang/moabang.type.ts
+++ b/components/community/moabang/moabang.type.ts
@@ -1,5 +1,5 @@
 export type PostAge = 'ALL' | 'INFANT' | 'AGE_3' | 'AGE_4' | 'AGE_5';
-export type ResourceType = 'ACTIVITY' | 'PLAN' | 'JOURNAL' | 'NOTICE' | 'ENVIRONMENT';
+export type ResourceType = 'ACTIVITY' | 'ENVIRONMENT' | 'PLAN' | 'DOCUMENT_FORM';
 
 export interface MoabangPost {
   postId: number;

--- a/components/community/write/write-selects.ts
+++ b/components/community/write/write-selects.ts
@@ -15,10 +15,9 @@ export const AGE_OPTIONS: SelectOption[] = [
 
 export const MATERIAL_TYPE_OPTIONS: SelectOption[] = [
   { label: '활동자료', value: 'ACTIVITY' },
-  { label: '계획안', value: 'PLAN' },
-  { label: '일지', value: 'JOURNAL' },
-  { label: '안내문', value: 'NOTICE' },
   { label: '환경구성', value: 'ENVIRONMENT' },
+  { label: '계획안', value: 'PLAN' },
+  { label: '문서/서식', value: 'DOCUMENT_FORM' },
 ];
 
 export const TOPIC_OPTIONS: SelectOption[] = [

--- a/components/home/ServiceSection.tsx
+++ b/components/home/ServiceSection.tsx
@@ -32,16 +32,6 @@ const SERVICE_CARDS = [
     lowerBg: '#FBC9CDE5',
   },
   {
-    label: '자유게시판',
-    description: '게시글 1개당\n생성횟수 1회 추가',
-    href: '/community/board',
-    characterSrc: ServiceBoardChar,
-    characterHoverSrc: ServiceBoardHoverChar,
-    mainColor: '#377A53',
-    upperBg: '#E9F6E6',
-    lowerBg: '#B7DDB1E5',
-  },
-  {
     label: '모아방',
     description: '자료공유 완료 시\n생성횟수 3회 추가',
     href: '/community/moabang',
@@ -50,6 +40,16 @@ const SERVICE_CARDS = [
     mainColor: '#A66B1F',
     upperBg: '#FFF9F0',
     lowerBg: '#FDEFD4E5',
+  },
+  {
+    label: '자유게시판',
+    description: '게시글 1개당\n생성횟수 1회 추가',
+    href: '/community/board',
+    characterSrc: ServiceBoardChar,
+    characterHoverSrc: ServiceBoardHoverChar,
+    mainColor: '#377A53',
+    upperBg: '#E9F6E6',
+    lowerBg: '#B7DDB1E5',
   },
 ];
 

--- a/constants/community/badge-variants.ts
+++ b/constants/community/badge-variants.ts
@@ -12,10 +12,9 @@ export const POST_AGE_VARIANT: Record<PostAge, BadgeVariant> = {
 
 export const RESOURCE_TYPE_VARIANT: Record<ResourceType, BadgeVariant> = {
   ACTIVITY: 'outline-yellow',
-  JOURNAL: 'outline-pink',
-  PLAN: 'outline-green',
-  NOTICE: 'outline-gray',
   ENVIRONMENT: 'outline-orange',
+  PLAN: 'outline-green',
+  DOCUMENT_FORM: 'outline-gray',
 };
 
 export const HEAD_TAG_VARIANT: Record<HeadTag, BadgeVariant> = {

--- a/constants/community/community-tabs.ts
+++ b/constants/community/community-tabs.ts
@@ -12,10 +12,9 @@ export const MOABANG_AGES: TabOption[] = [
 
 export const MOABANG_CATEGORIES: TabOption[] = [
   { label: '활동자료', value: 'ACTIVITY' },
-  { label: '계획안', value: 'PLAN' },
-  { label: '일지', value: 'JOURNAL' },
-  { label: '안내문', value: 'NOTICE' },
   { label: '환경구성', value: 'ENVIRONMENT' },
+  { label: '계획안', value: 'PLAN' },
+  { label: '문서/서식', value: 'DOCUMENT_FORM' },
 ];
 
 export const MOABANG_AGE_FILTER_TABS: TabOption[] = [ALL_TAB, ...MOABANG_AGES];


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 0.1.5 에서 나온 수정 사항들을 반영하는 작업 입니다.
- ## 주요 변경(무엇을?):
 - 버그리포트에 작성 된 부분들을 작업하였습니다.
## 변경 내용

- [x] 모바일 버튼 내 아이콘 잘림 현상
- [x] 모바일 검색 시 input 화면 이탈 및 뒤로가기 디자인 불일치
- [x] 모아방 탭 순서 및 변경 
- [x] 홈 서비스 카드 순서변경
- [x] 홈 스크롤 탑 버튼 수정 

### 세부 변경 사항

- 모바일 `>` 아이콘 잘림 → `ChevronRightIcon.svg`에 `overflow="visible"` 추가
- 검색 오버레이 뒤로가기 아이콘을 마이페이지와 동일하게 수정
- 모아방 카테고리: 활동자료 / 환경구성 / 계획안 / 문서/서식 으로 변경 (`JOURNAL`·`NOTICE` 제거, `DOCUMENT_FORM`) 추가 
- 홈 서비스 카드 순서: 관찰일지/모아방/자유게시판으로 변경
- 스크롤 탑 버튼 `xl: hidden` 해제

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [x] 로컬에서 `pnpm test` 통과
- [x] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Document/Template as a new resource type for community content creation.

* **Updates**
  * Removed Journal and Notice material types from available options.
  * Updated resource type availability and badge styling for community content.
  * Reorganized service section card layout.
  * Refined search overlay interface icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->