### PR TITLE
Fix: 0.1.5 QA 버그 수정 (#152)

### DIFF
--- a/components/common/nav-menu/NavMenu.tsx
+++ b/components/common/nav-menu/NavMenu.tsx
@@ -61,7 +61,7 @@ function ObservationNavItem({
         <Link
           href={`/observations/${log.observationId}`}
           onClick={onClose}
-          className="flex-1 truncate px-6 py-3.5 text-xs font-medium text-black-700 hover:rounded-lg hover:bg-black-200 md:px-9"
+          className="flex-1 truncate px-4 py-3.5 text-xs font-medium text-black-700 hover:rounded-lg hover:bg-black-200 md:px-9"
         >
           {log.title}
         </Link>
@@ -70,7 +70,7 @@ function ObservationNavItem({
             onClose();
             setShowDeleteDialog(true);
           }}
-          className="absolute top-1/2 right-6 -translate-y-1/2 md:right-9"
+          className="absolute top-1/2 right-5.5 -translate-y-1/2 md:right-11"
         />
       </li>
       <Dialog
@@ -147,7 +147,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
               <div key={section.href}>
                 <button
                   onClick={() => toggleSection(section.href)}
-                  className="flex w-full items-center justify-between py-3.75 pr-6 pl-4 text-base font-semibold md:px-9"
+                  className="flex w-full items-center justify-between p-4 py-3.75 pr-5.5 text-base font-semibold md:pr-11 md:pl-9"
                 >
                   <span className="text-black">{section.label}</span>
                   <ChevronDownIcon
@@ -165,14 +165,14 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                         <Link
                           href="/observations"
                           onClick={onClose}
-                          className="flex items-center gap-0.5 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                          className="flex items-center gap-0.5 rounded-lg px-4 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           <PlusIcon className="h-4 w-4 shrink-0" />새 관찰일지
                         </Link>
                         <Link
                           href="/mypage/observations"
                           onClick={onClose}
-                          className="mt-2 flex items-center gap-2 rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                          className="mt-2 flex items-center gap-2 rounded-lg px-4 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                         >
                           최근 관찰일지
                           {recentObservations && (
@@ -209,7 +209,7 @@ export default function NavMenu({ isOpen, onClose, onLogout }: NavMenuProps) {
                             <Link
                               href={child.href}
                               onClick={onClose}
-                              className="block rounded-lg px-6 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
+                              className="block rounded-lg px-4 py-3.5 text-xs font-semibold text-black hover:bg-black-200 md:px-9"
                             >
                               {child.label}
                             </Link>

--- a/components/common/select/Select.tsx
+++ b/components/common/select/Select.tsx
@@ -13,7 +13,7 @@ const SIZE_STYLES: Record<SelectSize, string> = {
 
 const TRIGGER_STYLES: Record<SelectSize, string> = {
   sm: 'justify-end',
-  md: 'justify-between rounded-lg border border-black-300',
+  md: 'justify-between rounded-lg border border-black-300 bg-white',
 };
 
 const ICON_SIZE: Record<SelectSize, number> = {

--- a/components/community/write/WriteCategorySelect.tsx
+++ b/components/community/write/WriteCategorySelect.tsx
@@ -122,11 +122,7 @@ export default function WriteCategorySelect({ values, onChange }: WriteCategoryS
     <div className={isFree ? 'grid grid-cols-2 gap-3' : 'grid grid-cols-2 gap-3 md:flex'}>
       <Select
         size="md"
-        className={
-          isFree
-            ? 'col-span-2 w-full bg-white md:col-span-1'
-            : 'col-span-2 w-full bg-white md:flex-1'
-        }
+        className={isFree ? 'col-span-2 w-full md:col-span-1' : 'col-span-2 w-full md:flex-1'}
         triggerLabel={BOARD_OPTIONS.find((o) => o.value === boardType)?.label ?? '게시판'}
         options={BOARD_OPTIONS}
         value={boardType}
@@ -136,7 +132,7 @@ export default function WriteCategorySelect({ values, onChange }: WriteCategoryS
         <>
           <Select
             size="md"
-            className="w-full bg-white md:flex-1"
+            className="w-full md:flex-1"
             triggerLabel={AGE_OPTIONS.find((o) => o.value === postAge)?.label ?? '연령'}
             options={AGE_OPTIONS}
             value={postAge}
@@ -144,7 +140,7 @@ export default function WriteCategorySelect({ values, onChange }: WriteCategoryS
           />
           <Select
             size="md"
-            className="w-full bg-white md:flex-1"
+            className="w-full md:flex-1"
             triggerLabel={
               MATERIAL_TYPE_OPTIONS.find((o) => o.value === resourceType)?.label ?? '자료 유형'
             }
@@ -157,7 +153,7 @@ export default function WriteCategorySelect({ values, onChange }: WriteCategoryS
       {boardType === 'free' && (
         <Select
           size="md"
-          className="col-span-2 w-full bg-white md:col-span-1"
+          className="col-span-2 w-full md:col-span-1"
           triggerLabel={TOPIC_OPTIONS.find((o) => o.value === headTag)?.label ?? '말머리'}
           options={TOPIC_OPTIONS}
           value={headTag}

--- a/components/mypage/bookmarks/BookmarksBoundary.tsx
+++ b/components/mypage/bookmarks/BookmarksBoundary.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { ChevronDownIcon } from '@/app/assets/icons';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 import BookmarksSection from './BookmarksSection';
 
 export default function BookmarksBoundary() {
@@ -17,6 +18,9 @@ export default function BookmarksBoundary() {
         <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">북마크</h1>
       </div>
       <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">북마크</h1>
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/comments/CommentsBoundary.tsx
+++ b/components/mypage/comments/CommentsBoundary.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { ChevronDownIcon } from '@/app/assets/icons';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 import CommentsSection from './CommentsSection';
 
 export default function CommentsBoundary() {
@@ -17,6 +18,9 @@ export default function CommentsBoundary() {
         <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">댓글</h1>
       </div>
       <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">댓글</h1>
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/dashboard/GenerationCount.tsx
+++ b/components/mypage/dashboard/GenerationCount.tsx
@@ -27,12 +27,20 @@ export function GenerationCount({ balance, total, className }: GenerationCountPr
 
       <div className="rounded-[20px] bg-white px-12.5 pt-11.25 pb-12.5">
         <div className="relative pt-10">
-          <Tooltip
-            label={remainingCount > 0 ? `${remainingCount}번 더 만들 수 있어요!` : '0개 남았어요!'}
-            className="-top-1.5"
-            labelClassName="md:text-xs text-[10px]"
-            style={{ left: `${Math.min(Math.max(progress, 5), 95)}%` }}
-          />
+          {remainingCount === total || remainingCount === 0 ? (
+            <div className="pointer-events-none absolute -top-4 left-1/2 z-200 -translate-x-1/2">
+              <div className="rounded-[20px] bg-pink-100 px-3.75 py-1.5 text-xs font-medium whitespace-nowrap text-pink-500 md:text-xs">
+                {`${remainingCount}개 남았어요!`}
+              </div>
+            </div>
+          ) : (
+            <Tooltip
+              label={`${remainingCount}번 더 만들 수 있어요!`}
+              className="-top-1.5"
+              labelClassName="md:text-xs text-[10px]"
+              style={{ left: `${Math.min(Math.max(progress, 5), 95)}%` }}
+            />
+          )}
           <ProgressBar progress={progress} />
         </div>
       </div>

--- a/components/mypage/dashboard/ProfileEditBottomSheet.tsx
+++ b/components/mypage/dashboard/ProfileEditBottomSheet.tsx
@@ -52,12 +52,13 @@ export function ProfileEditBottomSheet({
       hasClose={false}
     >
       <div className="flex h-102 flex-col px-4 pb-5 leading-[140%]">
-        <div className="mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
+        <div className="relative mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
           <Image
             src={profileImageUrl || DefaultAvatar}
             alt="프로필 아바타"
-            width={110}
-            height={110}
+            fill
+            sizes="110px"
+            className="object-contain"
           />
         </div>
 

--- a/components/mypage/dashboard/ProfileEditBottomSheet.tsx
+++ b/components/mypage/dashboard/ProfileEditBottomSheet.tsx
@@ -29,16 +29,20 @@ export function ProfileEditBottomSheet({
   const [displayName, setDisplayName] = useState(nickname);
   const router = useRouter();
 
-  const { mutate: handleUpdateProfile, isPending } = useProfileMutation({
-    onSuccess: () => {
-      onClose();
-      router.refresh();
-      toast.success({ title: '저장 완료', description: '변경사항이 저장되었어요' });
-    },
-    onError: () => {
-      toast.error({ title: '저장 실패', description: '잠시 후 다시 시도해주세요' });
-    },
-  });
+  const { mutate: handleUpdateProfile, isPending } = useProfileMutation();
+
+  function handleSave() {
+    handleUpdateProfile(displayName, {
+      onSuccess: () => {
+        onClose();
+        router.refresh();
+        toast.success({ title: '저장 완료', description: '변경사항이 저장되었어요' });
+      },
+      onError: () => {
+        toast.error({ title: '저장 실패', description: '잠시 후 다시 시도해주세요' });
+      },
+    });
+  }
 
   return (
     <BottomSheet
@@ -94,7 +98,7 @@ export function ProfileEditBottomSheet({
               variant="primary"
               size="sm"
               disabled={!displayName || isPending}
-              onClick={() => handleUpdateProfile(displayName)}
+              onClick={handleSave}
             >
               저장
             </Button>

--- a/components/mypage/dashboard/ProfileEditModal.tsx
+++ b/components/mypage/dashboard/ProfileEditModal.tsx
@@ -30,16 +30,20 @@ export function ProfileEditModal({
   const [displayName, setDisplayName] = useState(nickname);
   const router = useRouter();
 
-  const { mutate: handleUpdateProfile, isPending } = useProfileMutation({
-    onSuccess: () => {
-      onClose();
-      router.refresh();
-      toast.success({ title: '저장 완료', description: '변경사항이 저장되었어요' });
-    },
-    onError: () => {
-      toast.error({ title: '저장 실패', description: '잠시 후 다시 시도해주세요' });
-    },
-  });
+  const { mutate: handleUpdateProfile, isPending } = useProfileMutation();
+
+  function handleSave() {
+    handleUpdateProfile(displayName, {
+      onSuccess: () => {
+        onClose();
+        router.refresh();
+        toast.success({ title: '저장 완료', description: '변경사항이 저장되었어요' });
+      },
+      onError: () => {
+        toast.error({ title: '저장 실패', description: '잠시 후 다시 시도해주세요' });
+      },
+    });
+  }
 
   useEffect(() => {
     if (!isOpen) return;
@@ -112,7 +116,7 @@ export function ProfileEditModal({
                 variant="primary"
                 size="sm"
                 disabled={!displayName || isPending}
-                onClick={() => handleUpdateProfile(displayName)}
+                onClick={handleSave}
               >
                 저장
               </Button>

--- a/components/mypage/dashboard/ProfileEditModal.tsx
+++ b/components/mypage/dashboard/ProfileEditModal.tsx
@@ -70,12 +70,13 @@ export function ProfileEditModal({
             프로필 편집
           </h2>
 
-          <div className="mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
+          <div className="relative mx-auto my-8 h-27.5 w-27.5 overflow-hidden rounded-full">
             <Image
               src={profileImageUrl || DefaultAvatar}
               alt="프로필 아바타"
-              width={110}
-              height={110}
+              fill
+              sizes="110px"
+              className="object-contain"
             />
           </div>
 

--- a/components/mypage/observations/ObservationsBoundary.tsx
+++ b/components/mypage/observations/ObservationsBoundary.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { ChevronDownIcon } from '@/app/assets/icons';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 import ObservationsSection from './ObservationsSection';
 
 export default function ObservationsBoundary() {
@@ -19,6 +20,9 @@ export default function ObservationsBoundary() {
       <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">
         관찰일지 내역
       </h1>
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
       <AsyncBoundary
         pendingFallback={<LoadingSpinner className="pt-11.25" />}
         rejectedFallback={({ error, reset }) => (

--- a/components/mypage/posts/PostsBoundary.tsx
+++ b/components/mypage/posts/PostsBoundary.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ChevronDownIcon } from '@/app/assets/icons';
 import Tabs, { TabOption } from '@/components/common/tabs/Tabs';
 import { AsyncBoundary, LoadingSpinner, ErrorFallback } from '@/lib/async-boundary';
+import ScrollToTopButton from '@/components/common/scroll-top/ScrollToTopButton';
 import MoabangPostList from './MoabangPostList';
 import FreePostList from './FreePostList';
 
@@ -27,6 +28,9 @@ export default function PostsBoundary() {
         <h1 className="py-2 text-base font-semibold text-black md:text-[18px]">게시글</h1>
       </div>
       <h1 className="hidden text-lg font-semibold text-black xl:block xl:pt-[10.5px]">게시글</h1>
+      <div className="fixed right-9 bottom-9 z-300 xl:hidden">
+        <ScrollToTopButton showAfter={300} />
+      </div>
 
       <div className="mx-4 flex h-10 items-stretch rounded-lg bg-black-200 px-5 md:mx-9 xl:mx-0">
         <Tabs

--- a/hooks/queries/user/useProfile.ts
+++ b/hooks/queries/user/useProfile.ts
@@ -1,10 +1,16 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateProfile } from '@/api/user.api';
-import { User } from '@/types/user.type';
+import { communityKeys } from '@/hooks/queries/community/queryKeys';
 
-export function useProfileMutation(options?: UseMutationOptions<User, Error, string>) {
+export function useProfileMutation() {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    ...options,
     mutationFn: updateProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('moabang') });
+      queryClient.invalidateQueries({ queryKey: communityKeys.board('board') });
+      queryClient.invalidateQueries({ queryKey: ['post', 'detail'] });
+    },
   });
 }


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - QA 과정에서 확인된 버그 수정 및 개선
 
- ## 주요 변경(무엇을?):
  - 셀렉트 컴포넌트 모서리 배경색 노출 수정
  - 남은 생성 횟수 0개 또는 최대 상태 배지 디자인 변경
  - 마이페이지 모바일, 태블릿 스크롤 탑 버튼 추가
  - 닉네임 수정 시 커뮤니티 작성자 이름 갱신 처리
  - 프로필 편집 아바타 이미지 비율 깨짐 수정
  - 네비게이션 메뉴 모바일/태블릿 패딩 조정

## 변경 내용

- [x] 셀렉트(`size="md"`) 트리거에 `bg-white`를 옮겨 모서리 바깥 배경 노출 제거
- [x] 대시보드 생성 횟수 0개 또는 최대 상태에서 분홍 배지로 표시
- [x] 마이페이지 4개 페이지(관찰일지/게시글/댓글/북마크) 모바일, 태블릿 무한스크롤에 탑 버튼 추가
- [x] `useProfileMutation` 훅에서 커뮤니티 캐시 invalidate 처리 + community mutation 패턴으로 통일
- [x] 프로필 편집 모달/바텀시트의 아바타 이미지 `fill + object-contain`으로 변경
- [x] 네비게이션 메뉴 모바일/태블릿 좌우 패딩 및 삭제 버튼 위치 조정

### 세부 변경 사항

- `Select.tsx` `size="md"` 트리거 스타일에 `bg-white` 추가, `WriteCategorySelect.tsx`에서 Select 컨테이너 `bg-white` 제거
- `GenerationCount.tsx`에서 `balance === total` 또는 `balance === 0`일 때 기존 검은 툴팁 대신 가운데 고정 분홍 배지(`bg-pink-100`, `text-pink-500`) 렌더링
- `ObservationsBoundary`, `BookmarksBoundary`, `CommentsBoundary`, `PostsBoundary`에 `ScrollToTopButton`을 `fixed right-9 bottom-9 z-300 xl:hidden`으로 추가 (홈/커뮤니티와 동일
위치)
- `useProfile.ts` 시그니처에서 `options` 인자 제거, 훅 내부에서 `communityKeys.board('moabang')`, `communityKeys.board('board')`, `['post', 'detail']` invalidate 처리
- `ProfileEditModal.tsx` / `ProfileEditBottomSheet.tsx`에서 `mutate(displayName, { onSuccess, onError })` 형태로 호출하도록 변경
- 프로필 편집 아바타를 `relative` 컨테이너 + `<Image fill sizes="110px" className="object-contain" />`로 변경해 원형 컨테이너에서 비율 유지
- `NavMenu.tsx` 모바일 좌우 패딩 축소(`px-6` → `px-4`), 삭제 버튼 위치(`right-6` → `right-5.5`)와 태블릿 패딩(`md:px-9` → `md:pr-11 md:pl-9`) 조정

## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-to-top buttons on mobile and tablet views for Bookmarks, Comments, Observations, and Posts pages

* **Style**
  * Adjusted navigation menu spacing and padding
  * Updated select component styling with white backgrounds
  * Modified generation count message rendering

* **Refactor**
  * Profile editing save flow and image rendering updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/7-baduki/moassam-frontend/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->