### PR TITLE
Fix: 기존 스토리지 NCP -> GCP로 수정  (#156)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,7 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'picsum.photos' },
-      { protocol: 'https', hostname: 'kr.object.ncloudstorage.com' },
-      { protocol: 'https', hostname: 'moassam-storage.kr.object.ncloudstorage.com' },
+      { protocol: 'https', hostname: 'storage.googleapis.com' },
       { protocol: 'https', hostname: 'k.kakaocdn.net' },
     ],
   },


### PR DESCRIPTION
## 요약

- ## 변경 목적(왜?):
  - 기존 Storage를 NCP에서 GCP로 변경됨에 따라 `next/image`가 허용되지 않은 호스트의 이미지는 로딩하지 않기에 진행하게 되었습니다.
- ## 주요 변경(무엇을?):
  - `next.config` 에서 GCP 호스트 추가 및 NCP 호스트 제거
 ## 변경 내용

- [x] `next.config` 수정

### 세부 변경 사항

- `next.config` 에서 NCP 호스트 제거
`protocol: 'https', hostname: 'kr.object.ncloudstorage.com' ` 
`protocol: 'https', hostname: 'moassam-storage.kr.object.ncloudstorage.com'` 
- `next.config` 에서 GCP 호스트 추가 
`protocol: 'https', hostname: 'storage.googleapis.com'`
## 스크린샷/동영상 (선택)

<!-- UI 변경 있으면 첨부 -->

## 테스트

- [] 유닛 테스트 추가/수정됨
- [] 로컬에서 `pnpm test` 통과
- [] 타입체크/린트 통과 (`pnpm typecheck`, `pnpm lint`)

## 관련 이슈

- close #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image hosting configuration to support new storage infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->